### PR TITLE
Add build and deploy workflow

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -26,7 +26,7 @@ jobs:
           miniforge-variant: Mambaforge
           use-mamba: true
           activate-environment: deployment-docs-dev
-          environment-file: conda/environments/deployment_docs_cuda11.5.yml
+          environment-file: conda/environments/deployment_docs.yml
 
       - name: Build
         run: make html

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,8 +1,9 @@
 name: Build and deploy
 on:
   push:
-    branches:
-      - main
+    # TODO: Uncomment before merging
+    # branches:
+    #   - main
   pull_request:
 
 # Required shell entrypoint to have properly activated conda environments

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,0 +1,35 @@
+name: Build and deploy
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+# Required shell entrypoint to have properly activated conda environments
+defaults:
+  run:
+    shell: bash -l {0}
+
+jobs:
+  conda:
+    name: Build (and deploy)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3.1.0
+        with:
+          fetch-depth: 0
+      - name: Set up Python
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          miniforge-variant: Mambaforge
+          use-mamba: true
+          python-version: 3.8
+          activate-environment: deployment-docs-dev
+          environment-file: conda/environments/deployment_docs_cuda11.5.yml
+      - name: Build
+        run: make html
+
+      # TODO: If on main
+      # TODO: Checkout docs repo
+      # TODO: Move built site into right path (/deployment/nightly for commits and /deployment/stable for tags)
+      # TODO: Commit back to that repo

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -24,7 +24,6 @@ jobs:
         with:
           miniforge-variant: Mambaforge
           use-mamba: true
-          python-version: 3.8
           activate-environment: deployment-docs-dev
           environment-file: conda/environments/deployment_docs_cuda11.5.yml
       - name: Build

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,9 +1,8 @@
 name: Build and deploy
 on:
   push:
-    # TODO: Uncomment before merging
-    # branches:
-    #   - main
+    branches:
+      - main
   pull_request:
 
 # Required shell entrypoint to have properly activated conda environments

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
+
       - name: Set up Python
         uses: conda-incubator/setup-miniconda@v2
         with:
@@ -26,10 +27,20 @@ jobs:
           use-mamba: true
           activate-environment: deployment-docs-dev
           environment-file: conda/environments/deployment_docs_cuda11.5.yml
+
       - name: Build
         run: make html
 
-      # TODO: If on main
-      # TODO: Checkout docs repo
-      # TODO: Move built site into right path (/deployment/nightly for commits and /deployment/stable for tags)
-      # TODO: Commit back to that repo
+      # If on main in the upstream repo then push to docs repo
+      - name: Pushes build files
+        uses: cpina/github-action-push-to-another-repository@v1.5.1
+        if: ${{ github.repository == 'rapidsai/deployment' && github.event_name == 'push' }}
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.WORKFLOW_TOKEN }}
+        with:
+          source-directory: "build/html"
+          target-directory: ${{ startsWith(github.event.ref, 'refs/tags/') && 'deployment/stable' || 'deployment/nightly' }}
+          destination-github-username: "rapidsai"
+          destination-repository-name: "docs"
+          user-email: 1898282+github-actions[bot]@users.noreply.github.com
+          target-branch: gh-pages

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,6 +1,8 @@
 name: Build and deploy
 on:
   push:
+    tags:
+      - "*"
     branches:
       - main
   pull_request:


### PR DESCRIPTION
Add workflow to build docs and optionally deploy it.

All PRs will have the docs built as part of general testing that things are working ok.

If on `main` in the upstream `rapidsai/deployment` repo built HTML files are also committed to [the docs repo](https://github.com/rapidsai/docs/tree/gh-pages/deployment/) for publishing. Regular commits to `main` will be put at the `/deployment/nightly` path and tagged commits to the `/deployment/stable` path.

Closes #46