### PR TITLE
Use RAPIDS style and add dynamic nav

### DIFF
--- a/source/_static/js/nav.js
+++ b/source/_static/js/nav.js
@@ -7,21 +7,31 @@ document.addEventListener("DOMContentLoaded", function () {
             <a class="rapids-home-container__home-btn" href="/">Home</a>
         </div>
         <div class="rapids-selector__container rapids-selector--hidden">
-        <div class="rapids-selector__selected"></div>
-        <div class="rapids-selector__menu" style="height: 65px;">
-            <a class="rapids-selector__menu-item" href="https://docs.rapids.ai/deployment/nightly">nightly</a>
-            <a class="rapids-selector__menu-item" href="https://docs.rapids.ai/deployment/stable">stable</a>
+            <div class="rapids-selector__selected">deployment</div>
+            <div class="rapids-selector__menu" style="height: 65px;">
+                <a class="rapids-selector__menu-item rapids-selector__menu-item--selected" href="https://docs.rapids.ai/deployment">deployment</a>
+                <a class="rapids-selector__menu-item" href="https://docs.rapids.ai/api">api docs</a>
+            </div>
         </div>
+        <div id="rapids-selector__container-version" class="rapids-selector__container rapids-selector--hidden">
+            <div class="rapids-selector__selected"></div>
+            <div class="rapids-selector__menu" style="height: 65px;">
+                <a class="rapids-selector__menu-item" href="https://docs.rapids.ai/deployment/nightly">nightly</a>
+                <a class="rapids-selector__menu-item" href="https://docs.rapids.ai/deployment/stable">stable</a>
+            </div>
         </div>
     </div>
     ` + sidebar.innerHTML;
 
-  let selectorSelected = document.getElementsByClassName(
+  let versionSection = document.getElementById(
+    "rapids-selector__container-version"
+  );
+  let selectorSelected = versionSection.getElementsByClassName(
     "rapids-selector__selected"
   )[0];
   if (window.location.href.includes("/deployment/stable")) {
     selectorSelected.innerHTML = "stable";
-    document
+    versionSection
       .getElementsByClassName("rapids-selector__menu-item")
       .forEach((element) => {
         if (element.innerHTML.includes("stable")) {
@@ -30,7 +40,7 @@ document.addEventListener("DOMContentLoaded", function () {
       });
   } else if (window.location.href.includes("/deployment/nightly")) {
     selectorSelected.innerHTML = "nightly";
-    document
+    versionSection
       .getElementsByClassName("rapids-selector__menu-item")
       .forEach((element) => {
         if (element.innerHTML.includes("nightly")) {
@@ -39,7 +49,9 @@ document.addEventListener("DOMContentLoaded", function () {
       });
   } else {
     selectorSelected.innerHTML = "dev";
-    let menu = document.getElementsByClassName("rapids-selector__menu")[0];
+    let menu = versionSection.getElementsByClassName(
+      "rapids-selector__menu"
+    )[0];
     menu.innerHTML =
       menu.innerHTML +
       '<a class="rapids-selector__menu-item rapids-selector__menu-item--selected" href="/">dev</a>';

--- a/source/_static/js/nav.js
+++ b/source/_static/js/nav.js
@@ -1,0 +1,48 @@
+document.addEventListener("DOMContentLoaded", function () {
+  let sidebar = document.getElementsByClassName("bd-sidebar-primary")[0];
+  sidebar.innerHTML =
+    `
+    <div id="rapids-pydata-container">
+        <div class="rapids-home-container">
+            <a class="rapids-home-container__home-btn" href="/">Home</a>
+        </div>
+        <div class="rapids-selector__container rapids-selector--hidden">
+        <div class="rapids-selector__selected"></div>
+        <div class="rapids-selector__menu" style="height: 65px;">
+            <a class="rapids-selector__menu-item" href="https://docs.rapids.ai/deployment/nightly">nightly</a>
+            <a class="rapids-selector__menu-item" href="https://docs.rapids.ai/deployment/stable">stable</a>
+        </div>
+        </div>
+    </div>
+    ` + sidebar.innerHTML;
+
+  let selectorSelected = document.getElementsByClassName(
+    "rapids-selector__selected"
+  )[0];
+  if (window.location.href.includes("/deployment/stable")) {
+    selectorSelected.innerHTML = "stable";
+    document
+      .getElementsByClassName("rapids-selector__menu-item")
+      .forEach((element) => {
+        if (element.innerHTML.includes("stable")) {
+          element.classList.add("rapids-selector__menu-item--selected");
+        }
+      });
+  } else if (window.location.href.includes("/deployment/nightly")) {
+    selectorSelected.innerHTML = "nightly";
+    document
+      .getElementsByClassName("rapids-selector__menu-item")
+      .forEach((element) => {
+        if (element.innerHTML.includes("nightly")) {
+          element.classList.add("rapids-selector__menu-item--selected");
+        }
+      });
+  } else {
+    selectorSelected.innerHTML = "dev";
+    let menu = document.getElementsByClassName("rapids-selector__menu")[0];
+    menu.innerHTML =
+      menu.innerHTML +
+      '<a class="rapids-selector__menu-item rapids-selector__menu-item--selected" href="/">dev</a>';
+    menu.style["height"] = "97px";
+  }
+});

--- a/source/conf.py
+++ b/source/conf.py
@@ -69,3 +69,8 @@ intersphinx_mapping = {
     "distributed": ("https://distributed.dask.org/en/latest/", None),
     "dask_kubernetes": ("https://kubernetes.dask.org/en/latest/", None),
 }
+
+def setup(app):
+    app.add_css_file("https://docs.rapids.ai/assets/css/custom.css")
+    app.add_js_file("https://docs.rapids.ai/assets/js/custom.js", loading_method="defer")
+    app.add_js_file("js/nav.js", loading_method="defer")


### PR DESCRIPTION
This PR is trying to bring the deployment docs more in line with the other docs sites.

<img width="1387" alt="image" src="https://user-images.githubusercontent.com/1610850/196677477-4c7c8946-6a3d-4a63-bf04-58e16bac174c.png">

- Tested the latest `pydata-sphinx-theme`.
- Included the custom JavaScript and CSS files the rest of RAPIDS is using.
- Added some custom JS to dynamically generate the section and version selectors. Other projects use BeautifulSoup to postprocess the HTML files but I opted for JS to do this client-side to simplify the build pipeline. The deployment docs release process is a little different so this made more sense.