### PR TITLE
Align single node examples

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -2,5 +2,6 @@
   "default": true,
   "MD013": false,
   "MD014": false,
-  "MD033": false
+  "MD033": false,
+  "MD041": false
 }

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,1 @@
+source/_includes/*

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,1 +1,0 @@
-source/_includes/*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,4 @@ repos:
     rev: v0.31.1
     hooks:
       - id: markdownlint
+        args: [--ignore-path=.markdownlintignore]

--- a/source/_includes/install-rapids-with-docker.md
+++ b/source/_includes/install-rapids-with-docker.md
@@ -1,0 +1,14 @@
+There are a selection of methods you can use to install RAPIDS which you can see via the [RAPIDS release selector](https://rapids.ai/start.html#get-rapids).
+
+For this example we are going to run the RAPIDS Docker container so we need to know the name of the most recent container.
+On the release selector choose **Docker** in the **Method** column.
+
+Then copy the commands shown:
+
+```bash
+docker pull nvcr.io/nvidia/rapidsai/rapidsai-core:22.10-cuda11.5-runtime-ubuntu20.04-py3.9
+docker run --gpus all --rm -it \
+    --shm-size=1g --ulimit memlock=-1 \
+    -p 8888:8888 -p 8787:8787 -p 8786:8786 \
+    nvcr.io/nvidia/rapidsai/rapidsai-core:22.10-cuda11.5-runtime-ubuntu20.04-py3.9
+```

--- a/source/_includes/menus/aws.md
+++ b/source/_includes/menus/aws.md
@@ -1,0 +1,45 @@
+`````{grid} 1 2 2 3
+:gutter: 2 2 2 2
+
+````{grid-item-card}
+:link: /cloud/aws/ec2
+:link-type: doc
+Elastic Compute Cloud (EC2)
+^^^
+Launch an EC2 instance and run RAPIDS.
+
+{bdg-primary}`single-node`
+````
+
+````{grid-item-card}
+:link: /cloud/aws/eks
+:link-type: doc
+Elastic Kubernetes Service (EKS)
+^^^
+Launch a RAPIDS cluster on managed Kubernetes.
+
+{bdg-primary}`multi-node`
+````
+
+````{grid-item-card}
+:link: /cloud/aws/ecs
+:link-type: doc
+Elastic Container Service (ECS)
+^^^
+Launch a RAPIDS cluster on managed container service.
+
+{bdg-primary}`multi-node`
+````
+
+````{grid-item-card}
+:link: /cloud/aws/sagemaker
+:link-type: doc
+Sagemaker
+^^^
+Launch the RAPIDS container as a Sagemaker notebook.
+
+{bdg-primary}`single-node`
+{bdg-primary}`multi-node`
+````
+
+`````

--- a/source/_includes/menus/azure.md
+++ b/source/_includes/menus/azure.md
@@ -1,0 +1,14 @@
+`````{grid} 1 2 2 3
+:gutter: 2 2 2 2
+
+````{grid-item-card}
+:link: /cloud/azure/azure-vm
+:link-type: doc
+Azure Virtual Machine
+^^^
+Launch an Azure VM instance and run RAPIDS.
+
+{bdg-primary}`single-node`
+````
+
+`````

--- a/source/_includes/menus/gcp.md
+++ b/source/_includes/menus/gcp.md
@@ -6,7 +6,7 @@
 :link-type: doc
 Compute Engine Instance
 ^^^
-Launch an Compute Engine instance and run RAPIDS.
+Launch a Compute Engine instance and run RAPIDS.
 
 {bdg-primary}`single-node`
 ````

--- a/source/_includes/menus/gcp.md
+++ b/source/_includes/menus/gcp.md
@@ -1,0 +1,24 @@
+`````{grid} 1 2 2 3
+:gutter: 2 2 2 2
+
+````{grid-item-card}
+:link: /cloud/gcp/compute-engine
+:link-type: doc
+Compute Engine Instance
+^^^
+Launch an Compute Engine instance and run RAPIDS.
+
+{bdg-primary}`single-node`
+````
+
+````{grid-item-card}
+:link: /cloud/gcp/vertex-ai
+:link-type: doc
+Vertex AI
+^^^
+Launch the RAPIDS container in Vertex AI managed notebooks.
+
+{bdg-primary}`single-node`
+````
+
+`````

--- a/source/_includes/menus/ibm.md
+++ b/source/_includes/menus/ibm.md
@@ -1,0 +1,14 @@
+`````{grid} 1 2 2 3
+:gutter: 2 2 2 2
+
+````{grid-item-card}
+:link: /cloud/ibm/virtual-server
+:link-type: doc
+IBM Virtual Server
+^^^
+Launch a virtual server and run RAPIDS.
+
+{bdg-primary}`single-node`
+````
+
+`````

--- a/source/_includes/test-rapids-docker-vm.md
+++ b/source/_includes/test-rapids-docker-vm.md
@@ -1,0 +1,20 @@
+In the terminal we can open `ipython` and check that we can import and use RAPIDS libraries like `cudf`.
+
+```python
+In [1]: import cudf
+In [2]: df = cudf.datasets.timeseries()
+In [3]: df.head()
+Out[3]:
+                       id     name         x         y
+timestamp
+2000-01-01 00:00:00  1020    Kevin  0.091536  0.664482
+2000-01-01 00:00:01   974    Frank  0.683788 -0.467281
+2000-01-01 00:00:02  1000  Charlie  0.419740 -0.796866
+2000-01-01 00:00:03  1019    Edith  0.488411  0.731661
+2000-01-01 00:00:04   998    Quinn  0.651381 -0.525398
+```
+
+You can also access Jupyter via `<VM ip>:8888` in the browser.
+Visit `cudf/10-min.ipynb` and execute the cells to try things out.
+
+When running a Dask cluster you can also visit `<VM ip>:8787` to monitor the Dask cluster status.

--- a/source/cloud/aws/ec2.md
+++ b/source/cloud/aws/ec2.md
@@ -1,32 +1,35 @@
 # Elastic Compute Cloud (EC2)
 
-There are multiple ways you can deploy RAPIDS on a single instance, but the easiest is to use the RAPIDS docker image:
+## Create Instance
 
-**1. Initiate.** Initiate an instance supported by RAPIDS. See the introduction
-section for a list of supported instance types. It is recommended to use an AMI
-that already includes the required NVIDIA drivers, such as the **[AWS Deep Learning
-AMI.](https://docs.aws.amazon.com/dlami/latest/devguide/what-is-dlami.html)**
+Create a new [EC2 Instance](https://aws.amazon.com/ec2/) with GPUs, the [NVIDIA Driver](https://www.nvidia.co.uk/Download/index.aspx) and the [NVIDIA Container Runtime](https://developer.nvidia.com/nvidia-container-runtime).
 
-**2. Credentials.** Using the credentials supplied by AWS, log into the instance
-via SSH. For a short guide on launching your instance and accessing it, read the
-Getting Started with Amazon EC2 documentation.
+NVIDIA maintains an [Amazon Machine Image (AMI) that pre-installs NVIDIA drivers and container runtimes](https://aws.amazon.com/marketplace/pp/prodview-7ikjtg3um26wq), we recommend using this image as the starting point.
 
-**3. Install.** Install [Docker and the NVIDIA Docker
-runtime](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html)
-in the AWS instance. This step is not required if you are using AWS Deep
-Learning AMI.
+1. Open the [**EC2 Dashboard**](https://console.aws.amazon.com/ec2/home).
+1. Select **Launch Instance**.
+1. In the AMI selection box search for "nvidia", then switch to the **AWS Marketplace AMIs** tab.
+1. Select **NVIDIA GPU-Optimized VMI**, then select **Select** and then **Continue**.
+1. In **Key pair** select your SSH keys (create these first if you haven't already).
+1. Under network settings create a security group (or choose an existing) that allows SSH access on port `22` and also allow ports `8888,8786,8787` to access Jupyter and Dask.
+1. Select **Launch**.
 
-**4. Install.** Install RAPIDS docker image. The docker container can be
-customized by using the options provided in the **[Getting
-Started](https://rapids.ai/start.html)** page of RAPIDS. Example of an image
-that can be used is provided below:
+## Connect to the instance
 
-```shell
-$ docker pull rapidsai/rapidsai:22.10-cuda11.5-runtime-ubuntu18.04-py3.9
-$ docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-         rapidsai/rapidsai:22.10-cuda11.5-runtime-ubuntu18.04-py3.9
+Next we need to connect to the instance.
+
+1. Open the [**EC2 Dashboard**](https://console.aws.amazon.com/ec2/home).
+2. Locate your VM and note the **Public IP Address**.
+3. In your terminal run `ssh ubuntu@<ip address>`
+
+## Install RAPIDS
+
+```{include} ../../_includes/install-rapids-with-docker.md
+
 ```
 
-**5. Test RAPIDS.** Test it! The RAPIDS docker image will start a Jupyter
-notebook instance automatically. You can log into it by going to the IP address
-provided by AWS on port 8888.
+## Test RAPIDS
+
+```{include} ../../_includes/test-rapids-docker-vm.md
+
+```

--- a/source/cloud/aws/index.md
+++ b/source/cloud/aws/index.md
@@ -1,14 +1,11 @@
+---
+html_theme.sidebar_secondary.remove: true
+---
+
 # Amazon Web Services
 
-```{toctree}
----
-maxdepth: 2
-caption: Amazon Web Services
----
-ec2
-eks
-ecs
-sagemaker
+```{include} ../../_includes/menus/aws.md
+
 ```
 
 RAPIDS can be deployed on Amazon Web Services (AWS) in several ways. See the
@@ -32,3 +29,13 @@ list of accelerated instance types below:
 | AWS                 | G5              | g5\.12xlarge    | 4              | A10G          | 24 (GB)       |             96 (GB) |
 | AWS                 | G5              | g5\.24xlarge    | 4              | A10G          | 24 (GB)       |             96 (GB) |
 | AWS                 | G5              | g5\.48xlarge    | 8              | A10G          | 24 (GB)       |            192 (GB) |
+
+```{toctree}
+---
+hidden: true
+---
+ec2
+eks
+ecs
+sagemaker
+```

--- a/source/cloud/azure/azure-vm.md
+++ b/source/cloud/azure/azure-vm.md
@@ -4,8 +4,7 @@
 
 Create a new [Azure Virtual Machine](https://azure.microsoft.com/en-gb/products/virtual-machines/) with GPU, [NVIDIA Driver](https://www.nvidia.co.uk/Download/index.aspx) and [NVIDIA Container Runtime](https://developer.nvidia.com/nvidia-container-runtime).
 
-NVIDIA maintains a Virtual Machine Image (VMI) that pre-installs NVIDIA drivers and container runtimes,
-we recommend using [this image](https://azuremarketplace.microsoft.com/en-us/marketplace/apps/nvidia.ngc_azure_17_11?tab=Overview) as the starting point.
+NVIDIA maintains a [Virtual Machine Image (VMI) that pre-installs NVIDIA drivers and container runtimes](https://azuremarketplace.microsoft.com/en-us/marketplace/apps/nvidia.ngc_azure_17_11?tab=Overview), we recommend using this image as the starting point.
 
 `````{tab-set}
 
@@ -110,26 +109,15 @@ az network nsg rule create \
 
 ## Install RAPIDS
 
-It can take up to 10 minutes to provision a GPU VM. When available, [connect to the machine via SSH](https://learn.microsoft.com/en-us/azure/virtual-machines/linux-vm-connect) and install RAPIDS.
+```{include} ../../_includes/install-rapids-with-docker.md
 
-There are a selection of methods you can use to install RAPIDS which you can see via the [RAPIDS release selector](https://rapids.ai/start.html#get-rapids).
-For this example we are going to run the RAPIDS Docker container so we need to know the name of the most recent container.
-On the release selector choose `Docker` in the `METHOD` column. Then copy the commands shown:
-
-```bash
-docker pull nvcr.io/nvidia/rapidsai/rapidsai-core:22.10-cuda11.5-runtime-ubuntu20.04-py3.9
-docker run --gpus all --rm -it \
-    --shm-size=1g --ulimit memlock=-1 \
-    -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-    nvcr.io/nvidia/rapidsai/rapidsai-core:22.10-cuda11.5-runtime-ubuntu20.04-py3.9
 ```
 
 ## Test RAPIDS
 
-You can access Jupyter via `<VM ip>:8888` in the browser.
-Visit `cudf/10-min.ipynb` and execute the cells to try things out.
+```{include} ../../_includes/test-rapids-docker-vm.md
 
-When running a Dask cluster you can also visit `<VM ip>:8787` to monitor the Dask cluster status.
+```
 
 ### Useful Links
 

--- a/source/cloud/azure/azure-vm.md
+++ b/source/cloud/azure/azure-vm.md
@@ -2,7 +2,7 @@
 
 ## Create Virtual Machine
 
-Create a new [Azure Virtual Machine](https://azure.microsoft.com/en-gb/products/virtual-machines/) with GPU, [NVIDIA Driver](https://www.nvidia.co.uk/Download/index.aspx) and [NVIDIA Container Runtime](https://developer.nvidia.com/nvidia-container-runtime).
+Create a new [Azure Virtual Machine](https://azure.microsoft.com/en-gb/products/virtual-machines/) with GPUs, the [NVIDIA Driver](https://www.nvidia.co.uk/Download/index.aspx) and the [NVIDIA Container Runtime](https://developer.nvidia.com/nvidia-container-runtime).
 
 NVIDIA maintains a [Virtual Machine Image (VMI) that pre-installs NVIDIA drivers and container runtimes](https://azuremarketplace.microsoft.com/en-us/marketplace/apps/nvidia.ngc_azure_17_11?tab=Overview), we recommend using this image as the starting point.
 

--- a/source/cloud/azure/azure-vm.md
+++ b/source/cloud/azure/azure-vm.md
@@ -1,8 +1,10 @@
 # Azure Virtual Machine
 
-## Create Azure Virtual Machine with GPU, Nvidia Driver and Nvidia Container Runtime
+## Create Virtual Machine
 
-Nvidia maintains an image that pre-installs Nvidia drivers and container runtimes,
+Create a new [Azure Virtual Machine](https://azure.microsoft.com/en-gb/products/virtual-machines/) with GPU, [NVIDIA Driver](https://www.nvidia.co.uk/Download/index.aspx) and [NVIDIA Container Runtime](https://developer.nvidia.com/nvidia-container-runtime).
+
+NVIDIA maintains a Virtual Machine Image (VMI) that pre-installs NVIDIA drivers and container runtimes,
 we recommend using [this image](https://azuremarketplace.microsoft.com/en-us/marketplace/apps/nvidia.ngc_azure_17_11?tab=Overview) as the starting point.
 
 `````{tab-set}
@@ -11,9 +13,9 @@ we recommend using [this image](https://azuremarketplace.microsoft.com/en-us/mar
 :sync: portal
 
 
-1. Select the latest Nvidia GPU-Optimized VMI version from the drop down list, then select _Get It Now_.
-2. If already logged in on Azure, select continue clicking _Create_.
-3. In _Create a virtual machine_ interface, fill in required information for the vm.
+1. Select the latest **NVIDIA GPU-Optimized VMI** version from the drop down list, then select **Get It Now**.
+2. If already logged in on Azure, select continue clicking **Create**.
+3. In **Create a virtual machine** interface, fill in required information for the vm.
    Select a GPU enabled VM size.
 
 ```{dropdown} Note that not all regions support availability zones with GPU VMs.
@@ -27,7 +29,7 @@ support availability zone. Try other availability options.
 ![azure-gpuvm-availability-zone-error](../../_static/azure_availability_zone.PNG)
 ```
 
-Click _Review+Create_ to start the virtual machine.
+Click **Review+Create** to start the virtual machine.
 
 ````
 
@@ -36,15 +38,15 @@ Click _Review+Create_ to start the virtual machine.
 
 Prepare the following environment variables.
 
-| Name             | Description          | Example                                                      |
-| ---------------- | -------------------- | ------------------------------------------------------------ |
-| AZ_VMNAME        | Name for VM          | RapidsAI-V100                                                |
-| AZ_RESOURCEGROUP | Resource group of VM | rapidsai-deployment                                          |
-| AZ_LOCATION      | Region of VM         | westus2                                                      |
-| AZ_IMAGE         | URN of image         | nvidia:ngc_azure_17_11:ngc-base-version-22_06_0-gen2:22.06.0 |
-| AZ_SIZE          | VM Size              | Standard_NC6s_v3                                             |
-| AZ_USERNAME      | User name of VM      | rapidsai                                                     |
-| AZ_SSH_KEY       | public ssh key       | ~/.ssh/id_rsa.pub                                            |
+| Name               | Description          | Example                                                        |
+| ------------------ | -------------------- | -------------------------------------------------------------- |
+| `AZ_VMNAME`        | Name for VM          | `RapidsAI-V100`                                                |
+| `AZ_RESOURCEGROUP` | Resource group of VM | `rapidsai-deployment`                                          |
+| `AZ_LOCATION`      | Region of VM         | `westus2`                                                      |
+| `AZ_IMAGE`         | URN of image         | `nvidia:ngc_azure_17_11:ngc-base-version-22_06_0-gen2:22.06.0` |
+| `AZ_SIZE`          | VM Size              | `Standard_NC6s_v3`                                             |
+| `AZ_USERNAME`      | User name of VM      | `rapidsai`                                                     |
+| `AZ_SSH_KEY`       | public ssh key       | `~/.ssh/id_rsa.pub`                                            |
 
 ```bash
 az vm create \
@@ -59,7 +61,7 @@ az vm create \
 
 ```{note}
 Use `az vm image list --publisher Nvidia --all --output table` to inspect URNs of official
-Nvidia images on Azure.
+NVIDIA images on Azure.
 ```
 
 ```{note}
@@ -73,24 +75,26 @@ for supported ssh keys on Azure.
 
 ## Create Network Security Group
 
+Next we need to allow network traffic to the VM so we can access Jupyter and Dask.
+
 `````{tab-set}
 
 ````{tab-item} via Azure Portal
 :sync: portal
 
-1. Select _Networking_ in the left panel.
-2. Select _Add inbound port rule_.
-3. Set _Destination port ranges_ to `8888,8787`. Keep rest unchanged. Select _Add_.
+1. Select **Networking** in the left panel.
+2. Select **Add inbound port rule**.
+3. Set **Destination port ranges** to `8888,8787`. Keep rest unchanged. Select **Add**.
 
 ````
 
 ````{tab-item} via Azure CLI
 :sync: cli
 
-| Name           | Description         | Example                  |
-| -------------- | ------------------- | ------------------------ |
-| AZ_NSGNAME     | NSG name for the VM | ${AZ_VMNAME}NSG          |
-| AZ_NSGRULENAME | Name for NSG rule   | Allow-Dask-Jupyter-ports |
+| Name             | Description         | Example                    |
+| ---------------- | ------------------- | -------------------------- |
+| `AZ_NSGNAME`     | NSG name for the VM | `${AZ_VMNAME}NSG`          |
+| `AZ_NSGRULENAME` | Name for NSG rule   | `Allow-Dask-Jupyter-ports` |
 
 ```bash
 az network nsg rule create \
@@ -106,10 +110,11 @@ az network nsg rule create \
 
 ## Install RAPIDS
 
-It can take up to 10 minutes to provision a GPU VM. When available, ssh into the machine.
+It can take up to 10 minutes to provision a GPU VM. When available, [connect to the machine via SSH](https://learn.microsoft.com/en-us/azure/virtual-machines/linux-vm-connect) and install RAPIDS.
 
-Visit [rapids release selector](https://rapids.ai/start.html#get-rapids) and choose `Docker` in `METHOD`
-column. For example, to pull 22.10 stable image and run the container:
+There are a selection of methods you can use to install RAPIDS which you can see via the [RAPIDS release selector](https://rapids.ai/start.html#get-rapids).
+For this example we are going to run the RAPIDS Docker container so we need to know the name of the most recent container.
+On the release selector choose `Docker` in the `METHOD` column. Then copy the commands shown:
 
 ```bash
 docker pull nvcr.io/nvidia/rapidsai/rapidsai-core:22.10-cuda11.5-runtime-ubuntu20.04-py3.9
@@ -121,9 +126,10 @@ docker run --gpus all --rm -it \
 
 ## Test RAPIDS
 
-Access the jupyter-lab portal via `<ip>:8888` in the browser. Visit `cudf/10-min.ipynb` and
-execute the cells. Open dask dashboard on the left and enter `<ip>:8787` in the url blank
-to monitor dask worker status.
+You can access Jupyter via `<VM ip>:8888` in the browser.
+Visit `cudf/10-min.ipynb` and execute the cells to try things out.
+
+When running a Dask cluster you can also visit `<VM ip>:8787` to monitor the Dask cluster status.
 
 ### Useful Links
 

--- a/source/cloud/azure/index.md
+++ b/source/cloud/azure/index.md
@@ -1,3 +1,7 @@
+---
+html_theme.sidebar_secondary.remove: true
+---
+
 # Microsoft Azure
 
 ```{include} ../../_includes/menus/azure.md

--- a/source/cloud/azure/index.md
+++ b/source/cloud/azure/index.md
@@ -1,11 +1,7 @@
 # Microsoft Azure
 
-```{toctree}
----
-maxdepth: 2
-caption: Microsoft Azure
----
-azure-vm
+```{include} ../../_includes/menus/azure.md
+
 ```
 
 RAPIDS can be deployed on Microsoft Azure in several ways. Azure supports various kinds of GPU VMs for different needs.
@@ -41,3 +37,10 @@ ND (>=v2) series
 
 - [GPU VM availability by region](https://azure.microsoft.com/en-us/explore/global-infrastructure/products-by-region/?products=virtual-machines)
 - [For GPU VM sizes overview](https://learn.microsoft.com/en-us/azure/virtual-machines/sizes-gpu)
+
+```{toctree}
+---
+hidden: true
+---
+azure-vm
+```

--- a/source/cloud/gcp/compute-engine.md
+++ b/source/cloud/gcp/compute-engine.md
@@ -53,7 +53,3 @@ Next we need to connect to the VM.
 ```{include} ../../_includes/test-rapids-docker-vm.md
 
 ```
-
-### Useful Links
-
-- [Using NGC with Azure](https://docs.nvidia.com/ngc/ngc-azure-setup-guide/index.html)

--- a/source/cloud/gcp/compute-engine.md
+++ b/source/cloud/gcp/compute-engine.md
@@ -1,34 +1,59 @@
 # Compute Engine Instance
 
-The easiest way to deploy RAPIDS on a single instance is to use the `rapidsai/rapidsai` Docker image.
+## Create Virtual Machine
 
-**1. Create a VM instance.** In the GCP console, nagivate to `Compute Engine` -> `VM instances` -> `CREATE INSTANCE`.
+Create a new [Compute Engine Instance](https://cloud.google.com/compute/docs/instances) with GPUs, the [NVIDIA Driver](https://www.nvidia.co.uk/Download/index.aspx) and the [NVIDIA Container Runtime](https://developer.nvidia.com/nvidia-container-runtime).
 
-Under the `Machine configuration` setting, select `GPU` and choose your NVIDIA GPU type and number.
+NVIDIA maintains a [Virtual Machine Image (VMI) that pre-installs NVIDIA drivers and container runtimes](https://console.cloud.google.com/marketplace/product/nvidia-ngc-public/nvidia-gpu-optimized-vmi), we recommend using this image.
 
-Next under the `Container` setting, select `Deploy Container` and specify your preferred registry location of the `rapidsai/rapidsai` as your container image and check `Allocate a buffer for STDIN` and `Allocate a pseudo-TTY` to enable interactivty with the container.
+1. Open [**Compute Engine**](https://console.cloud.google.com/compute/instances).
+1. Select **Create Instance**.
+1. Select **Marketplace**.
+1. Search for "nvidia" and select **NVIDIA GPU-Optimized VMI**, then select **Launch**.
+1. In the **New NVIDIA GPU-Optimized VMI deployment** interface, fill in the name and any required information for the vm (the defaults should be fine for most users).
+1. **Read and accept** the Terms of Service
+1. Select **Deploy** to start the virtual machine.
 
-After customizing other aspects of your VM, click `CREATE` to initialize the VM.
+## Allow network access
 
-For the `gcloud` CLI, you can use the `gcloud compute instances create-with-container` command with at _minimum_ flags:
+To access Jupyter and Dask we will need to set up some firewall rules to open up some ports.
 
-```shell
-$ gcloud compute instances create-with-container $INSTANCE_NAME --container-image=$IMAGE_PATH --accelerator=count=$GPU_NUMBER,type=$GPU_TYPE --container-stdin --container-tty
+### Create the firewall rule
+
+1. Open [**VPC Network**](https://console.cloud.google.com/networking/networks/list).
+2. Select **Firewall** and **Create firewall rule**
+3. Give the rule a name like `rapids` and ensure the network matches the one you selected for the VM.
+4. Add a tag like `rapids` which we will use to assign the rule to our VM.
+5. Set your source IP range. We recommend you restrict this to your own IP address or your corporate network rather than `0.0.0.0/0` which will allow anyone to access your VM.
+6. Under **Protocols and ports** allow TCP connections on ports `8786,8787,8888`.
+
+### Assign it to the VM
+
+1. Open [**Compute Engine**](https://console.cloud.google.com/compute/instances).
+2. Select your VM and press **Edit**.
+3. Scroll down to **Networking** and add the `rapids` network tag you gave your firewall rule.
+4. Select **Save**.
+
+## Connect to the VM
+
+Next we need to connect to the VM.
+
+1. Open [**Compute Engine**](https://console.cloud.google.com/compute/instances).
+2. Locate your VM and press the **SSH** button which will open a new browser tab with a terminal.
+3. **Read and accept** the NVIDIA installer prompts.
+
+## Install RAPIDS
+
+```{include} ../../_includes/install-rapids-with-docker.md
+
 ```
 
-**2. Test RAPIDS.**
+## Test RAPIDS
 
-Once the VM is running, you can SSH into the VM from the GCP console or using the `gcloud` CLI using `gcloud compute ssh` and `docker attach` to the container enter a shell to start using RAPIDS.
+```{include} ../../_includes/test-rapids-docker-vm.md
 
-```shell
-USER@VM-NAME ~ $ docker attach $CONTAINER_ID
-(rapids) root@VM-NAME:/rapids/notebooks# conda list cudf
-# packages in environment at /opt/conda/envs/rapids:
-#
-# Name                    Version                   Build  Channel
-cudf                      22.08.00        cuda_11_py39_gb71873c701_0    rapidsai
-cudf_kafka                22.08.00        py39_gb71873c701_0    rapidsai
-dask-cudf                 22.08.00        cuda_11_py39_gb71873c701_0    rapidsai
-libcudf                   22.08.00        cuda11_gb71873c701_0    rapidsai
-libcudf_kafka             22.08.00          gb71873c701_0    rapidsai
 ```
+
+### Useful Links
+
+- [Using NGC with Azure](https://docs.nvidia.com/ngc/ngc-azure-setup-guide/index.html)

--- a/source/cloud/gcp/index.md
+++ b/source/cloud/gcp/index.md
@@ -1,3 +1,7 @@
+---
+html_theme.sidebar_secondary.remove: true
+---
+
 # Google Cloud Platform
 
 ```{include} ../../_includes/menus/gcp.md

--- a/source/cloud/gcp/index.md
+++ b/source/cloud/gcp/index.md
@@ -1,12 +1,15 @@
 # Google Cloud Platform
 
+```{include} ../../_includes/menus/gcp.md
+
+```
+
+RAPIDS can be deployed on Google Cloud Platform in several ways. Google Cloud supports various kinds of GPU VMs for different needs. Please visit the Google Cloud documentation for [an overview of GPU VM sizes](https://cloud.google.com/compute/docs/gpus) and [GPU VM availability by region](https://cloud.google.com/compute/docs/gpus/gpu-regions-zones).
+
 ```{toctree}
 ---
-maxdepth: 2
-caption: Google Cloud Platform
+hidden: true
 ---
 compute-engine
 vertex-ai
 ```
-
-RAPIDS can be deployed on Google Cloud Platform in several ways. Google Cloud supports various kinds of GPU VMs for different needs. Please visit the Google Cloud documentation for [an overview of GPU VM sizes](https://cloud.google.com/compute/docs/gpus) and [GPU VM availability by region](https://cloud.google.com/compute/docs/gpus/gpu-regions-zones).

--- a/source/cloud/ibm/index.md
+++ b/source/cloud/ibm/index.md
@@ -1,3 +1,7 @@
+---
+html_theme.sidebar_secondary.remove: true
+---
+
 # IBM Cloud
 
 ```{include} ../../_includes/menus/ibm.md

--- a/source/cloud/ibm/index.md
+++ b/source/cloud/ibm/index.md
@@ -1,11 +1,7 @@
 # IBM Cloud
 
-```{toctree}
----
-maxdepth: 2
-caption: IBM Cloud
----
-virtual-server
+```{include} ../../_includes/menus/ibm.md
+
 ```
 
 RAPIDS can be deployed on IBM Cloud in several ways. See the
@@ -22,4 +18,11 @@ list of accelerated instance types below:
 
 ```{warning}
 *Bare Metal instances are billed in monthly intervals rather than hourly intervals.
+```
+
+```{toctree}
+---
+hidden: true
+---
+virtual-server
 ```

--- a/source/cloud/ibm/virtual-server.md
+++ b/source/cloud/ibm/virtual-server.md
@@ -1,42 +1,87 @@
-# Virtual Server
+# Virtual Server for VPC
 
-There are multiple ways you can deploy RAPIDS on a single instance, but the easiest is to use the RAPIDS docker image:
+## Create Instance
 
-## Launch a VM instance
+Create a new [Virtual Server (for VPC)](https://www.ibm.com/cloud/virtual-servers) with GPUs, the [NVIDIA Driver](https://www.nvidia.co.uk/Download/index.aspx) and the [NVIDIA Container Runtime](https://developer.nvidia.com/nvidia-container-runtime).
 
-Launch an instance supported by RAPIDS. See the [introduction section for a list of supported instance types](index).
+1. Open the [**Virtual Server Dashboard**](https://cloud.ibm.com/vpc-ext/compute/vs).
+1. Select **Create**.
+1. Give the server a **name** and select your **resource group**.
+1. Under **Operating System** choose **Ubuntu Linux**.
+1. Under **Profile** select **View all profiles** and select a profile with NVIDIA GPUs.
+1. Under **SSH Keys** choose your SSH key.
+1. Under network settings create a security group (or choose an existing) that allows SSH access on port `22` and also allow ports `8888,8786,8787` to access Jupyter and Dask.
+1. Select **Create Virtual Server**.
 
-## Configure networking
+## Create floating IP
 
-Create a Floating IP and associate that with the created instance to access the instance on the web.
+To access the virtual server we need to attach a public IP address.
 
-## Login
+1. Open [**Floating IPs**](https://cloud.ibm.com/vpc-ext/network/floatingIPs)
+1. Select **Reserve**.
+1. Give the Floating IP a **name**.
+1. Under **Resource to bind** select the virtual server you just created.
 
-Using the credentials supplied by IBM, log into the instance
-via SSH. For a short guide on launching your instance and accessing it, read the
+## Connect to the instance
+
+Next we need to connect to the instance.
+
+1. Open [**Floating IPs**](https://cloud.ibm.com/vpc-ext/network/floatingIPs)
+1. Locate the IP you just created and note the address.
+1. In your terminal run `ssh root@<ip address>`
+
+```{note}
+For a short guide on launching your instance and accessing it, read the
 [Getting Started with IBM Virtual Server Documentation](https://cloud.ibm.com/docs/virtual-servers?topic=virtual-servers-getting-started-tutorial).
+```
 
-## Install pre-requisites
+## Install NVIDIA Drivers
 
-Install the [NVIDIA drivers](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#nvidia-drivers) and [Docker and the NVIDIA Docker
-runtime](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html)
-in the IBM virtual server instance.
+Next we need to install the NVIDIA drivers and container runtime.
+
+1. Ensure build essentials are installed `apt-get update && apt-get install build-essential -y`.
+1. Install the [NVIDIA drivers](https://www.nvidia.com/Download/index.aspx?lang=en-us).
+1. Install [Docker and the NVIDIA Docker runtime](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html).
+
+````{dropdown} How do I check everything installed successfully?
+:color: info
+:icon: info
+
+You can check everything installed correctly by running `nvidia-smi` in a container.
+
+```console
+$ docker run --rm --gpus all nvidia/cuda:11.6.2-base-ubuntu20.04 nvidia-smi
++-----------------------------------------------------------------------------+
+| NVIDIA-SMI 510.108.03   Driver Version: 510.108.03   CUDA Version: 11.6     |
+|-------------------------------+----------------------+----------------------+
+| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
+|                               |                      |               MIG M. |
+|===============================+======================+======================|
+|   0  Tesla V100-PCIE...  Off  | 00000000:04:01.0 Off |                    0 |
+| N/A   33C    P0    36W / 250W |      0MiB / 16384MiB |      0%      Default |
+|                               |                      |                  N/A |
++-------------------------------+----------------------+----------------------+
+
++-----------------------------------------------------------------------------+
+| Processes:                                                                  |
+|  GPU   GI   CI        PID   Type   Process name                  GPU Memory |
+|        ID   ID                                                   Usage      |
+|=============================================================================|
+|  No running processes found                                                 |
++-----------------------------------------------------------------------------+
+```
+
+````
 
 ## Install RAPIDS
 
-Install RAPIDS docker image. The docker container can be
-customized by using the options provided in the **[Getting
-Started](https://rapids.ai/start.html)** page of RAPIDS. Example of an image
-that can be used is provided below:
+```{include} ../../_includes/install-rapids-with-docker.md
 
-```shell
-$ docker pull rapidsai/rapidsai:22.10-cuda11.5-runtime-ubuntu20.04-py3.9
-$ docker run --gpus all --rm -it --shm-size=1g --ulimit memlock=-1 -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-    rapidsai/rapidsai:22.10-cuda11.5-runtime-ubuntu20.04-py3.9
 ```
 
 ## Test RAPIDS
 
-Test it! The RAPIDS docker image will start a Jupyter
-notebook instance automatically. You can log into it by going to the Floating IP address
-associated with the instance on port 8888.
+```{include} ../../_includes/test-rapids-docker-vm.md
+
+```

--- a/source/cloud/index.md
+++ b/source/cloud/index.md
@@ -6,112 +6,27 @@ html_theme.sidebar_secondary.remove: true
 
 ## Amazon Web Services
 
-`````{grid} 1 2 2 3
-:gutter: 2 2 2 2
+```{include} ../_includes/menus/aws.md
 
-````{grid-item-card}
-:link: aws/ec2
-:link-type: doc
-Elastic Compute Cloud (EC2)
-^^^
-Launch an EC2 instance and run RAPIDS.
-
-{bdg-primary}`single-node`
-````
-
-````{grid-item-card}
-:link: aws/eks
-:link-type: doc
-Elastic Kubernetes Service (EKS)
-^^^
-Launch a RAPIDS cluster on managed Kubernetes.
-
-{bdg-primary}`multi-node`
-````
-
-````{grid-item-card}
-:link: aws/ecs
-:link-type: doc
-Elastic Container Service (ECS)
-^^^
-Launch a RAPIDS cluster on managed container service.
-
-{bdg-primary}`multi-node`
-````
-
-````{grid-item-card}
-:link: aws/sagemaker
-:link-type: doc
-Sagemaker
-^^^
-Launch the RAPIDS container as a Sagemaker notebook.
-
-{bdg-primary}`single-node`
-{bdg-primary}`multi-node`
-````
-
-`````
+```
 
 ## Microsoft Azure
 
-`````{grid} 1 2 2 3
-:gutter: 2 2 2 2
+```{include} ../_includes/menus/azure.md
 
-````{grid-item-card}
-:link: azure/azure-vm
-:link-type: doc
-Azure Virtual Machine
-^^^
-Launch an Azure VM instance and run RAPIDS.
-
-{bdg-primary}`single-node`
-````
-
-`````
+```
 
 ## Google Cloud Platforms
 
-`````{grid} 1 2 2 3
-:gutter: 2 2 2 2
+```{include} ../_includes/menus/gcp.md
 
-````{grid-item-card}
-:link: gcp/compute-engine
-:link-type: doc
-Compute Engine Instance
-^^^
-Launch an Compute Engine instance and run RAPIDS.
-
-{bdg-primary}`single-node`
-````
-
-````{grid-item-card}
-:link: gcp/vertex-ai
-:link-type: doc
-Vertex AI
-^^^
-Launch the RAPIDS container in Vertex AI managed notebooks.
-
-{bdg-primary}`single-node`
-````
-
-`````
+```
 
 ## IBM Cloud
 
-`````{grid} 1 2 2 3
-:gutter: 2 2 2 2
+```{include} ../_includes/menus/ibm.md
 
-````{grid-item-card}
-:link: ibm/virtual-server
-:link-type: doc
-IBM Virtual Server
-^^^
-Launch a virtual server and run RAPIDS.
-
-{bdg-primary}`single-node`
-````
-
-`````
+```
 
 ```{toctree}
 :maxdepth: 2


### PR DESCRIPTION
We now have Single Node examples for AWS, Azure, GCP and IBM Cloud but they were all slightly different.

This PR is a refactor inspired from the best of each page to make them all consistent with each other.

I've also used some includes so that duplicated sections like pulling the Docker image and testing the RAPIDS install is only written once. 

I also tweaked the menus a bit.