### PR TITLE
DOC: Add Coiled documentation

### DIFF
--- a/source/index.md
+++ b/source/index.md
@@ -65,6 +65,7 @@ Use RAPIDS on compute platforms.
 
 {bdg-primary}`Kubernetes`
 {bdg-primary}`Kubeflow`
+{bdg-primary}`Coiled`
 {bdg-primary}`Databricks`
 ````
 

--- a/source/platforms/coiled.md
+++ b/source/platforms/coiled.md
@@ -1,0 +1,3 @@
+# Coiled
+
+You can deploy RAPIDS on a mulit-node Dask cluster with GPUs using [Coiled](https://www.coiled.io/). By using the [`coiled`](https://anaconda.org/conda-forge/coiled) Python library, you can setup and manage Dask clusters with GPUs and RAPIDs on cloud computing environments such as GCP or AWS. Please visit Coiled's [getting started guide](https://docs.coiled.io/user_guide/getting_started.html) for setting up the service and the [GPU quickstart guide](https://docs.coiled.io/user_guide/gpu.html) to learn how to deploy and use Dask clusters with GPUs and RAPIDS.

--- a/source/platforms/index.md
+++ b/source/platforms/index.md
@@ -26,6 +26,16 @@ Integrate RAPIDS with Kubeflow notebooks and pipelines.
 ````
 
 ````{grid-item-card}
+:link: coiled
+:link-type: doc
+Coiled
+^^^
+Run RAPIDS on Coiled.
+
+{bdg-primary}`multi-node`
+````
+
+````{grid-item-card}
 :link: databricks
 :link-type: doc
 Databricks
@@ -44,5 +54,6 @@ Run RAPIDS on Databricks.
 
 kubernetes
 kubeflow
+coiled
 databricks
 ```


### PR DESCRIPTION
closes #25

At the time of this PR the Coiled docs site was down for me, but this establishes a page for Coiled linking to their GPU quickstart guide