### PR TITLE
Update GCP Instance instructions for 22.12

### DIFF
--- a/source/_includes/install-rapids-with-docker.md
+++ b/source/_includes/install-rapids-with-docker.md
@@ -6,9 +6,9 @@ On the release selector choose **Docker** in the **Method** column.
 Then copy the commands shown:
 
 ```bash
-docker pull nvcr.io/nvidia/rapidsai/rapidsai-core:22.10-cuda11.5-runtime-ubuntu20.04-py3.9
+docker pull rapidsai/rapidsai-core:22.12-cuda11.5-runtime-ubuntu20.04-py3.9
 docker run --gpus all --rm -it \
     --shm-size=1g --ulimit memlock=-1 \
     -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-    nvcr.io/nvidia/rapidsai/rapidsai-core:22.10-cuda11.5-runtime-ubuntu20.04-py3.9
+    rapidsai/rapidsai-core:22.12-cuda11.5-runtime-ubuntu20.04-py3.9
 ```

--- a/source/cloud/gcp/compute-engine.md
+++ b/source/cloud/gcp/compute-engine.md
@@ -53,3 +53,7 @@ Next we need to connect to the VM.
 ```{include} ../../_includes/test-rapids-docker-vm.md
 
 ```
+
+## Clean up
+
+Once you are finished head back to the [Deployments](https://console.cloud.google.com/dm/deployments) page and delete the marketplace deployment you created.


### PR DESCRIPTION
- Update container image to `22.12` (used DockerHub as NGC images are not yet published)
- Added some clean up instructions.