### PR TITLE
Add legacy warning to ECS docs

### DIFF
--- a/source/cloud/aws/ecs.md
+++ b/source/cloud/aws/ecs.md
@@ -1,5 +1,9 @@
 # Elastic Container Service (ECS)
 
+```{warning}
+This is a legacy page and may contain outdated information. We are working hard to update our documentation with the latest and greatest information, thank you for bearing with us.
+```
+
 RAPIDS can be deployed on a multi-node ECS cluster using Dask’s
 dask-cloudprovider management tools. For more details, see our **[blog post on
 deploying on


### PR DESCRIPTION
The ECS docs here are copied from rapids.ai/cloud and most likely do not work, we have a ticket open to track rewriting it (#79) but it didn't make it into 22.12.

I'm keen to get rapids.ai/cloud redirecting here because the majority of the documentation has been updated and the deployment docs are a much more useful resource than rapids.ai/cloud. So I want to clearly signal that this page is still legacy with a warning and go ahead with the redirect.

<img width="1361" alt="image" src="https://user-images.githubusercontent.com/1610850/208120776-718002ba-e2b4-4dd6-8fa1-5190df35b2c1.png">
