### PR TITLE
Delete Gateway stub for now

### DIFF
--- a/source/tools/index.md
+++ b/source/tools/index.md
@@ -44,14 +44,6 @@ Dask Helm Chart
 Install a single user notebook and cluster on Kubernetes with the Dask Helm Chart.
 ````
 
-````{grid-item-card}
-:link: kubernetes/dask-gateway
-:link-type: doc
-Dask Gateway
-^^^
-Centrally enable and manage cluster creation on Kubernetes with Dask gateway.
-````
-
 `````
 
 ```{toctree}
@@ -63,5 +55,4 @@ rapids-docker
 kubernetes/dask-kubernetes
 kubernetes/dask-operator
 kubernetes/dask-helm-chart
-kubernetes/dask-gateway
 ```

--- a/source/tools/kubernetes/dask-gateway.md
+++ b/source/tools/kubernetes/dask-gateway.md
@@ -1,1 +1,0 @@
-# Dask Gateway


### PR DESCRIPTION
#8 didn't make it into 22.12 so proposing we remove the stub pages for now. They can be recreated when #8 lands.