### PR TITLE
Delete Databricks stub for now

### DIFF
--- a/source/platforms/databricks.md
+++ b/source/platforms/databricks.md
@@ -1,1 +1,0 @@
-# Databricks

--- a/source/platforms/index.md
+++ b/source/platforms/index.md
@@ -35,16 +35,6 @@ Run RAPIDS on Coiled.
 {bdg-primary}`multi-node`
 ````
 
-````{grid-item-card}
-:link: databricks
-:link-type: doc
-Databricks
-^^^
-Run RAPIDS on Databricks.
-
-{bdg-primary}`multi-node`
-````
-
 `````
 
 ```{toctree}
@@ -55,5 +45,4 @@ Run RAPIDS on Databricks.
 kubernetes
 kubeflow
 coiled
-databricks
 ```


### PR DESCRIPTION
The Databricks page is still a stub which may be confusing for users. Created #92 to track populating the page and removing the stub for now.