### PR TITLE
Simplify development setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,7 @@
 
 ## Building
 
-As a prerequisite, a RAPIDS compatible GPU is required to build the docs since the notebooks in the docs execute the code to generate the HTML output.
-
-In order to build the docs, we need the conda dev environment from cudf and build cudf from source.
-See build [instructions](https://github.com/rapidsai/cudf/blob/branch-0.13/CONTRIBUTING.md#setting-up-your-build-environment).
+In order to build the documentation install the required tools by following the steps below.
 
 1. Create a conda env with the dependencies to build the deployment docs from source.
 

--- a/conda/environments/deployment_docs.yml
+++ b/conda/environments/deployment_docs.yml
@@ -9,6 +9,7 @@ dependencies:
   - numpydoc
   - pydata-sphinx-theme
   - python=3.9
+  - pre-commit
   - sphinx
   - sphinx-autobuild
   - sphinx-copybutton


### PR DESCRIPTION
Building the docs no longer requires a GPU or cudf, this simplifies the setup as you no longer need a GPU or a bleeding edge build of cudf.

I also added pre-commit to the environment file. Seems like a good way to get the tool without needing instructions for different platforms.