### PR TITLE
Add ruff to the repo linters

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,3 +10,8 @@ repos:
     hooks:
       - id: markdownlint
         args: [--ignore-path=.markdownlintignore]
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    # Ruff version.
+    rev: "v0.0.231"
+    hooks:
+      - id: ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
 [tool.ruff]
 line-length = 120
-select = ["E", "F", "I"]
+select = ["E", "F", "I", "UP", "B"]
 fix = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
 [tool.ruff]
 line-length = 120
-select = ["I"]
+select = ["E", "F", "I"]
 fix = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.ruff]
+line-length = 120
+select = ["I"]
+fix = true

--- a/source/conf.py
+++ b/source/conf.py
@@ -10,11 +10,11 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
+import datetime
 import os
 import sys
 
 sys.path.insert(0, os.path.abspath("../extensions"))
-import datetime
 
 # -- Project information -----------------------------------------------------
 

--- a/source/conf.py
+++ b/source/conf.py
@@ -16,7 +16,6 @@ import sys
 sys.path.insert(0, os.path.abspath("../extensions"))
 import datetime
 
-
 # -- Project information -----------------------------------------------------
 
 project = "RAPIDS Deployment Documentation"

--- a/source/examples/rapids-sagemaker-higgs/rapids-higgs.py
+++ b/source/examples/rapids-sagemaker-higgs/rapids-higgs.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# coding: utf-8
 
 import argparse
 
@@ -15,7 +14,7 @@ def main(args):
     data_dir = args.data_dir
 
     col_names = ["label"] + [
-        "col-{}".format(i) for i in range(2, 30)
+        f"col-{i}" for i in range(2, 30)
     ]  # Assign column names
     dtypes_ls = ["int32"] + [
         "float32" for _ in range(2, 30)

--- a/source/examples/rapids-sagemaker-higgs/rapids-higgs.py
+++ b/source/examples/rapids-sagemaker-higgs/rapids-higgs.py
@@ -1,66 +1,63 @@
 #!/usr/bin/env python
 # coding: utf-8
 
+import argparse
+
+import cudf
 from cuml import RandomForestClassifier as cuRF
 from cuml.preprocessing.model_selection import train_test_split
-import cudf
-import numpy as np
-import pandas as pd
 from sklearn.metrics import accuracy_score
-import os
-from urllib.request import urlretrieve
-import gzip
-import argparse
 
 
 def main(args):
-    
+
     # SageMaker options
-    model_dir       = args.model_dir
-    data_dir        = args.data_dir
-        
-    col_names = ['label'] + ["col-{}".format(i) for i in range(2, 30)] # Assign column names
-    dtypes_ls = ['int32'] + ['float32' for _ in range(2, 30)] # Assign dtypes to each column
-    
-    data = cudf.read_csv(data_dir+'HIGGS.csv', names=col_names, dtype=dtypes_ls)
-    X_train, X_test, y_train, y_test = train_test_split(data, 'label', train_size=0.70)
+    data_dir = args.data_dir
+
+    col_names = ["label"] + [
+        "col-{}".format(i) for i in range(2, 30)
+    ]  # Assign column names
+    dtypes_ls = ["int32"] + [
+        "float32" for _ in range(2, 30)
+    ]  # Assign dtypes to each column
+
+    data = cudf.read_csv(data_dir + "HIGGS.csv", names=col_names, dtype=dtypes_ls)
+    X_train, X_test, y_train, y_test = train_test_split(data, "label", train_size=0.70)
 
     # Hyper-parameters
-    hyperparams={
-    'n_estimators'       : args.n_estimators,
-    'max_depth'          : args.max_depth,
-    'n_bins'             : args.n_bins,
-    'split_criterion'    : args.split_criterion,
-    'bootstrap'          : args.bootstrap,
-    'max_leaves'         : args.max_leaves,
-    'max_features'       : args.max_features
+    hyperparams = {
+        "n_estimators": args.n_estimators,
+        "max_depth": args.max_depth,
+        "n_bins": args.n_bins,
+        "split_criterion": args.split_criterion,
+        "bootstrap": args.bootstrap,
+        "max_leaves": args.max_leaves,
+        "max_features": args.max_features,
     }
 
     cu_rf = cuRF(**hyperparams)
     cu_rf.fit(X_train, y_train)
 
-    print("test_acc:", accuracy_score(cu_rf.predict(X_test), y_test)
+    print("test_acc:", accuracy_score(cu_rf.predict(X_test), y_test))
 
-    
+
 if __name__ == "__main__":
-    
+
     parser = argparse.ArgumentParser()
-    
+
     # Hyper-parameters
-    parser.add_argument('--n_estimators',        type=int,   default=20)
-    parser.add_argument('--max_depth',           type=int,   default=16)
-    parser.add_argument('--n_bins',              type=int,   default=8)
-    parser.add_argument('--split_criterion',     type=int,   default=0)
-    parser.add_argument('--bootstrap',           type=bool,  default=True)
-    parser.add_argument('--max_leaves',          type=int,   default=-1)
-    parser.add_argument('--max_features',        type=float, default=0.2)
-    
+    parser.add_argument("--n_estimators", type=int, default=20)
+    parser.add_argument("--max_depth", type=int, default=16)
+    parser.add_argument("--n_bins", type=int, default=8)
+    parser.add_argument("--split_criterion", type=int, default=0)
+    parser.add_argument("--bootstrap", type=bool, default=True)
+    parser.add_argument("--max_leaves", type=int, default=-1)
+    parser.add_argument("--max_features", type=float, default=0.2)
+
     # SageMaker parameters
-    parser.add_argument('--model_dir',        type=str)
-    parser.add_argument('--model_output_dir', type=str,   default='/opt/ml/output/')
-    parser.add_argument('--data_dir',         type=str,   default='/opt/ml/input/data/dataset/')
-    
+    parser.add_argument("--model_dir", type=str)
+    parser.add_argument("--model_output_dir", type=str, default="/opt/ml/output/")
+    parser.add_argument("--data_dir", type=str, default="/opt/ml/input/data/dataset/")
+
     args = parser.parse_args()
     main(args)
-
-


### PR DESCRIPTION
Folks seem to be excited about [ruff](https://github.com/charliermarsh/ruff) as a fast replacement for `flake8`/`isort`/`pyupgrade`/etc. 

Using it in the deployment docs for linting the example scripts and Sphinx extensions felt like a low-effort/low-risk place to try it out.

I've added it to the `pre-commit` config so it will get run on commit and in CI. You can optionally install it yourself with `pip install ruff` and run it on files with `ruff path/to/file.py`. 