### PR TITLE
Add notebook gallery with tag filter

### DIFF
--- a/extensions/rapids_related_examples.py
+++ b/extensions/rapids_related_examples.py
@@ -114,10 +114,6 @@ def build_tag_map(app: Sphinx, env: BuildEnvironment, docnames: list[str]):
 
     env.notebook_tag_map = {}
 
-    # If no pages are being rebuilt skip generating the tag map
-    # if not docnames:
-    #     return
-
     # Build notebook tag map
     for doc in env.found_docs:
         path = app.env.doc2path(doc)

--- a/extensions/rapids_related_examples.py
+++ b/extensions/rapids_related_examples.py
@@ -6,6 +6,7 @@ from docutils.parsers.rst.states import RSTState
 from docutils.statemachine import ViewList
 from markdown_it import MarkdownIt
 from sphinx.application import Sphinx
+from sphinx.directives.other import TocTree
 from sphinx.environment import BuildEnvironment
 from sphinx.util.docutils import SphinxDirective
 from sphinx.util.nodes import nested_parse_with_titles
@@ -46,7 +47,7 @@ def generate_notebook_grid_myst(
         md.append("^" * len(notebook))
         md.append("")
         for tag in read_notebook_tags(env.doc2path(notebook)):
-            md.append("{bdg-primary}`" + tag.split("/")[-1] + "`")
+            md.append("{bdg}`" + tag + "`")
         md.append("````")
         md.append("")
 
@@ -114,8 +115,8 @@ def build_tag_map(app: Sphinx, env: BuildEnvironment, docnames: list[str]):
     env.notebook_tag_map = {}
 
     # If no pages are being rebuilt skip generating the tag map
-    if not docnames:
-        return
+    # if not docnames:
+    #     return
 
     # Build notebook tag map
     for doc in env.found_docs:
@@ -135,9 +136,44 @@ def build_tag_map(app: Sphinx, env: BuildEnvironment, docnames: list[str]):
                 docnames.append(doc)
 
 
+def add_notebook_tag_map_to_context(app, pagename, templatename, context, doctree):
+    context["sorted"] = sorted
+    context["notebook_tag_map"] = app.env.notebook_tag_map
+    tag_tree = {}
+    for tag in app.env.notebook_tag_map:
+        root, suffix = tag.split("/", 1)
+        try:
+            tag_tree[root].append(suffix)
+        except KeyError:
+            tag_tree[root] = [suffix]
+    context["notebook_tag_tree"] = tag_tree
+
+
+class NotebookGalleryTocTree(TocTree):
+    def run(self) -> list[nodes.Node]:
+        output = nodes.section(ids=["examplegallery"])
+
+        # Generate the actual toctree but ensure it is hidden
+        self.options["hidden"] = True
+        toctree = super().run()
+        output += toctree
+
+        # Generate the card grid for all items in the toctree
+        notebooks = [
+            notebook for _, notebook in toctree[0].children[0].attributes["entries"]
+        ]
+        grid_markdown = generate_notebook_grid_myst(notebooks=notebooks, env=self.env)
+        for node in parse_markdown(markdown=grid_markdown, state=self.state):
+            output += node
+
+        return [output]
+
+
 def setup(app: Sphinx) -> dict:
     app.connect("env-before-read-docs", build_tag_map)
+    app.connect("html-page-context", add_notebook_tag_map_to_context)
     app.add_directive("relatedexamples", RelatedExamples)
+    app.add_directive("notebookgallerytoctree", NotebookGalleryTocTree)
 
     return {
         "version": "0.1",

--- a/source/_includes/menus/aws.md
+++ b/source/_includes/menus/aws.md
@@ -8,7 +8,7 @@ Elastic Compute Cloud (EC2)
 ^^^
 Launch an EC2 instance and run RAPIDS.
 
-{bdg-primary}`single-node`
+{bdg}`single-node`
 ````
 
 ````{grid-item-card}
@@ -18,7 +18,7 @@ Elastic Kubernetes Service (EKS)
 ^^^
 Launch a RAPIDS cluster on managed Kubernetes.
 
-{bdg-primary}`multi-node`
+{bdg}`multi-node`
 ````
 
 ````{grid-item-card}
@@ -28,7 +28,7 @@ Elastic Container Service (ECS)
 ^^^
 Launch a RAPIDS cluster on managed container service.
 
-{bdg-primary}`multi-node`
+{bdg}`multi-node`
 ````
 
 ````{grid-item-card}
@@ -38,8 +38,8 @@ Sagemaker
 ^^^
 Launch the RAPIDS container as a Sagemaker notebook.
 
-{bdg-primary}`single-node`
-{bdg-primary}`multi-node`
+{bdg}`single-node`
+{bdg}`multi-node`
 ````
 
 `````

--- a/source/_includes/menus/azure.md
+++ b/source/_includes/menus/azure.md
@@ -8,7 +8,7 @@ Azure Virtual Machine
 ^^^
 Launch an Azure VM instance and run RAPIDS.
 
-{bdg-primary}`single-node`
+{bdg}`single-node`
 ````
 
 ````{grid-item-card}
@@ -18,7 +18,7 @@ Azure Kubernetes Service (AKS)
 ^^^
 Launch a RAPIDS cluster on managed Kubernetes.
 
-{bdg-primary}`multi-node`
+{bdg}`multi-node`
 ````
 
 ````{grid-item-card}
@@ -28,7 +28,7 @@ Azure Cluster via Dask
 ^^^
 Launch a RAPIDS cluster on Azure VMs or Azure ML with Dask.
 
-{bdg-primary}`multi-node`
+{bdg}`multi-node`
 ````
 
 ````{grid-item-card}
@@ -38,7 +38,7 @@ Azure Machine Learning (Azure ML)
 ^^^
 Launch a RAPIDS cluster on Azure ML.
 
-{bdg-primary}`multi-node`
+{bdg}`multi-node`
 ````
 
 `````

--- a/source/_includes/menus/gcp.md
+++ b/source/_includes/menus/gcp.md
@@ -8,7 +8,7 @@ Compute Engine Instance
 ^^^
 Launch a Compute Engine instance and run RAPIDS.
 
-{bdg-primary}`single-node`
+{bdg}`single-node`
 ````
 
 ````{grid-item-card}
@@ -18,7 +18,7 @@ Vertex AI
 ^^^
 Launch the RAPIDS container in Vertex AI managed notebooks.
 
-{bdg-primary}`single-node`
+{bdg}`single-node`
 ````
 
 ````{grid-item-card}
@@ -28,7 +28,7 @@ Google Kubernetes Engine (GKE)
 ^^^
 Launch a RAPIDS cluster on managed Kubernetes.
 
-{bdg-primary}`multi-node`
+{bdg}`multi-node`
 ````
 
 ````{grid-item-card}
@@ -38,7 +38,7 @@ Dataproc
 ^^^
 Launch a RAPIDS cluster on Dataproc.
 
-{bdg-primary}`multi-node`
+{bdg}`multi-node`
 ````
 
 `````

--- a/source/_includes/menus/ibm.md
+++ b/source/_includes/menus/ibm.md
@@ -8,7 +8,7 @@ IBM Virtual Server
 ^^^
 Launch a virtual server and run RAPIDS.
 
-{bdg-primary}`single-node`
+{bdg}`single-node`
 ````
 
 `````

--- a/source/_static/css/custom.css
+++ b/source/_static/css/custom.css
@@ -1,56 +1,63 @@
 nav.bd-links fieldset legend {
-    color: var(--pst-color-text-base);
-    font-weight: var(--pst-sidebar-header-font-weight);
-    font-size: 1em;
+  color: var(--pst-color-text-base);
+  font-weight: var(--pst-sidebar-header-font-weight);
+  font-size: 1em;
 }
 
 nav.bd-links fieldset input {
-    margin-left: 1em;
-    margin-right: 0.25em;
-  }
+  margin-left: 1em;
+  margin-right: 0.25em;
+}
 
 .bd-links__title small {
-    float: right;
-    padding-right: 2em;
+  float: right;
+  padding-right: 2em;
 }
 
 nav.bd-links fieldset .sd-badge {
-    font-size: 0.9em;
+  font-size: 0.9em;
 }
 
 /* Tag colours */
 .sd-badge {
-    /* Defaults */
-    color: var(--sd-color-primary-text);
-    background-color: var(--sd-color-primary);
-    border-left: 0.5em var(--sd-color-primary) solid;
-    padding-left: 0.25em !important;
+  /* Defaults */
+  color: var(--sd-color-primary-text);
+  background-color: var(--sd-color-primary);
+  border-left: 0.5em var(--sd-color-primary) solid;
+  padding-left: 0.25em !important;
 }
 
-.tag-dask, .tag-dask-kubernetes, .tag-dask-operator, .tag-dask-yarn, .tag-dask-gateway, .tag-dask-jobqueue, .tag-dask-helm-chart {
-    color: #262326;
-    background-color: #FFC11E !important;
-    border-left: 0.5em #FFC11E solid;
+.tag-dask,
+.tag-dask-kubernetes,
+.tag-dask-operator,
+.tag-dask-yarn,
+.tag-dask-gateway,
+.tag-dask-jobqueue,
+.tag-dask-helm-chart {
+  color: #262326;
+  background-color: #ffc11e !important;
+  border-left: 0.5em #ffc11e solid;
 }
 
-.tag-kubernetes, .tag-kubeflow {
-    background-color: #3069DE;
-    border-left: 0.5em #3069DE solid;
+.tag-kubernetes,
+.tag-kubeflow {
+  background-color: #3069de;
+  border-left: 0.5em #3069de solid;
 }
 
 .tag-aws {
-    color: #222E3C;
-    background-color: #F79700;
-    border-left: 0.5em #F79700 solid;
+  color: #222e3c;
+  background-color: #f79700;
+  border-left: 0.5em #f79700 solid;
 }
 
 .tag-optuna {
-    background-color: #045895;
-    border-left: 0.5em #045895 solid;
+  background-color: #045895;
+  border-left: 0.5em #045895 solid;
 }
 
 .tag-scikit-learn {
-    color: #030200;
-    background-color: #F09436;
-    border-left: 0.5em #3194C7 solid;
+  color: #030200;
+  background-color: #f09436;
+  border-left: 0.5em #3194c7 solid;
 }

--- a/source/_static/css/custom.css
+++ b/source/_static/css/custom.css
@@ -1,0 +1,56 @@
+nav.bd-links fieldset legend {
+    color: var(--pst-color-text-base);
+    font-weight: var(--pst-sidebar-header-font-weight);
+    font-size: 1em;
+}
+
+nav.bd-links fieldset input {
+    margin-left: 1em;
+    margin-right: 0.25em;
+  }
+
+.bd-links__title small {
+    float: right;
+    padding-right: 2em;
+}
+
+nav.bd-links fieldset .sd-badge {
+    font-size: 0.9em;
+}
+
+/* Tag colours */
+.sd-badge {
+    /* Defaults */
+    color: var(--sd-color-primary-text);
+    background-color: var(--sd-color-primary);
+    border-left: 0.5em var(--sd-color-primary) solid;
+    padding-left: 0.25em !important;
+}
+
+.tag-dask, .tag-dask-kubernetes, .tag-dask-operator, .tag-dask-yarn, .tag-dask-gateway, .tag-dask-jobqueue, .tag-dask-helm-chart {
+    color: #262326;
+    background-color: #FFC11E !important;
+    border-left: 0.5em #FFC11E solid;
+}
+
+.tag-kubernetes, .tag-kubeflow {
+    background-color: #3069DE;
+    border-left: 0.5em #3069DE solid;
+}
+
+.tag-aws {
+    color: #222E3C;
+    background-color: #F79700;
+    border-left: 0.5em #F79700 solid;
+}
+
+.tag-optuna {
+    background-color: #045895;
+    border-left: 0.5em #045895 solid;
+}
+
+.tag-scikit-learn {
+    color: #030200;
+    background-color: #F09436;
+    border-left: 0.5em #3194C7 solid;
+}

--- a/source/_static/js/notebook-gallery.js
+++ b/source/_static/js/notebook-gallery.js
@@ -1,9 +1,10 @@
 document.addEventListener("DOMContentLoaded", function () {
 
     var tagFilterListener = function () {
-        filterTags = []
-        filterTagRoots = []
 
+        // Get filter checkbox status
+        filterTagRoots = []  // Which sections are we filtering on
+        filterTags = []  // Which tags are being selected
         Array.from(document.getElementsByClassName("tag-filter")).forEach(checkbox => {
             if (checkbox.checked) {
                 let tag = checkbox.getAttribute("id")
@@ -15,15 +16,19 @@ document.addEventListener("DOMContentLoaded", function () {
             }
         });
 
+        // Iterate notebook cards
         Array.from(document.getElementsByClassName("sd-col")).forEach(notebook => {
             let isFiltered = false
 
+            // Get tags from the card
             let tags = []
             Array.from(notebook.getElementsByClassName("sd-badge")).forEach(tag => {
                 tags.push(tag.getAttribute("aria-label"))
             })
 
+            // Iterate each of the sections we are filtering on
             filterTagRoots.forEach(rootTag => {
+
                 // If a notebook has no tags with the current root tag then it is definitely filtered
                 if (!tags.some(tag => { return tag.startsWith(rootTag) })) {
                     isFiltered = true
@@ -44,6 +49,7 @@ document.addEventListener("DOMContentLoaded", function () {
                 }
             })
 
+            // Show/hide the card
             if (isFiltered) {
                 notebook.setAttribute('style', 'display:none !important');
             } else {
@@ -64,7 +70,7 @@ document.addEventListener("DOMContentLoaded", function () {
         }, false);
     }
 
-    // Add listeners to all checkboxes
+    // Add listeners to all checkboxes for triggering filtering
     Array.from(document.getElementsByClassName("tag-filter")).forEach(checkbox => {
         checkbox.addEventListener('change', tagFilterListener, false);
     })

--- a/source/_static/js/notebook-gallery.js
+++ b/source/_static/js/notebook-gallery.js
@@ -1,0 +1,85 @@
+document.addEventListener("DOMContentLoaded", function () {
+
+    var tagFilterListener = function () {
+        filterTags = []
+        filterTagRoots = []
+
+        Array.from(document.getElementsByClassName("tag-filter")).forEach(checkbox => {
+            if (checkbox.checked) {
+                let tag = checkbox.getAttribute("id")
+                filterTags.push(checkbox.getAttribute("id"));
+                let root = tag.split("/")[0]
+                if (!filterTagRoots.includes(root)) {
+                    filterTagRoots.push(root)
+                }
+            }
+        });
+
+        Array.from(document.getElementsByClassName("sd-col")).forEach(notebook => {
+            let isFiltered = false
+
+            let tags = []
+            Array.from(notebook.getElementsByClassName("sd-badge")).forEach(tag => {
+                tags.push(tag.getAttribute("aria-label"))
+            })
+
+            filterTagRoots.forEach(rootTag => {
+                // If a notebook has no tags with the current root tag then it is definitely filtered
+                if (!tags.some(tag => { return tag.startsWith(rootTag) })) {
+                    isFiltered = true
+
+                } else {
+                    // Get filter tags with the current root we are testing
+                    let tagsWithRoot = []
+                    filterTags.forEach(filteredTag => {
+                        if (filteredTag.startsWith(rootTag)) {
+                            tagsWithRoot.push(filteredTag)
+                        }
+                    })
+
+                    // If the notebook tags and filter tags don't intersect it is filtered
+                    if (!tags.some(item => tagsWithRoot.includes(item))) {
+                        isFiltered = true
+                    }
+                }
+            })
+
+            if (isFiltered) {
+                notebook.setAttribute('style', 'display:none !important');
+            } else {
+                notebook.setAttribute('style', 'display:flex');
+            }
+
+        });
+    };
+
+    // Add listener for resetting the filters
+    let resetButton = document.getElementById("resetfilters")
+    if (resetButton != undefined) {
+        resetButton.addEventListener('click', function () {
+            Array.from(document.getElementsByClassName("tag-filter")).forEach(checkbox => {
+                checkbox.checked = false;
+            });
+            tagFilterListener()
+        }, false);
+    }
+
+    // Add listeners to all checkboxes
+    Array.from(document.getElementsByClassName("tag-filter")).forEach(checkbox => {
+        checkbox.addEventListener('change', tagFilterListener, false);
+    })
+
+    // Simplify tags and add class for styling
+    // It's not possible to control these attributes in Sphinx otherwise we would
+    Array.from(document.getElementsByClassName("sd-badge")).forEach(tag => {
+        tag.setAttribute("aria-label", tag.innerHTML);
+        try {
+            tag.getAttribute("aria-label").split("/").forEach(subtag => tag.classList.add(`tag-${subtag}`))
+        } catch (err) { }
+
+        if (tag.innerHTML.includes("/")) {
+            tag.innerHTML = tag.innerHTML.split('/').slice(1).join('/')
+        }
+
+    });
+});

--- a/source/_static/js/notebook-gallery.js
+++ b/source/_static/js/notebook-gallery.js
@@ -1,91 +1,106 @@
 document.addEventListener("DOMContentLoaded", function () {
-
-    var tagFilterListener = function () {
-
-        // Get filter checkbox status
-        filterTagRoots = []  // Which sections are we filtering on
-        filterTags = []  // Which tags are being selected
-        Array.from(document.getElementsByClassName("tag-filter")).forEach(checkbox => {
-            if (checkbox.checked) {
-                let tag = checkbox.getAttribute("id")
-                filterTags.push(checkbox.getAttribute("id"));
-                let root = tag.split("/")[0]
-                if (!filterTagRoots.includes(root)) {
-                    filterTagRoots.push(root)
-                }
-            }
-        });
-
-        // Iterate notebook cards
-        Array.from(document.getElementsByClassName("sd-col")).forEach(notebook => {
-            let isFiltered = false
-
-            // Get tags from the card
-            let tags = []
-            Array.from(notebook.getElementsByClassName("sd-badge")).forEach(tag => {
-                tags.push(tag.getAttribute("aria-label"))
-            })
-
-            // Iterate each of the sections we are filtering on
-            filterTagRoots.forEach(rootTag => {
-
-                // If a notebook has no tags with the current root tag then it is definitely filtered
-                if (!tags.some(tag => { return tag.startsWith(rootTag) })) {
-                    isFiltered = true
-
-                } else {
-                    // Get filter tags with the current root we are testing
-                    let tagsWithRoot = []
-                    filterTags.forEach(filteredTag => {
-                        if (filteredTag.startsWith(rootTag)) {
-                            tagsWithRoot.push(filteredTag)
-                        }
-                    })
-
-                    // If the notebook tags and filter tags don't intersect it is filtered
-                    if (!tags.some(item => tagsWithRoot.includes(item))) {
-                        isFiltered = true
-                    }
-                }
-            })
-
-            // Show/hide the card
-            if (isFiltered) {
-                notebook.setAttribute('style', 'display:none !important');
-            } else {
-                notebook.setAttribute('style', 'display:flex');
-            }
-
-        });
-    };
-
-    // Add listener for resetting the filters
-    let resetButton = document.getElementById("resetfilters")
-    if (resetButton != undefined) {
-        resetButton.addEventListener('click', function () {
-            Array.from(document.getElementsByClassName("tag-filter")).forEach(checkbox => {
-                checkbox.checked = false;
-            });
-            tagFilterListener()
-        }, false);
-    }
-
-    // Add listeners to all checkboxes for triggering filtering
-    Array.from(document.getElementsByClassName("tag-filter")).forEach(checkbox => {
-        checkbox.addEventListener('change', tagFilterListener, false);
-    })
-
-    // Simplify tags and add class for styling
-    // It's not possible to control these attributes in Sphinx otherwise we would
-    Array.from(document.getElementsByClassName("sd-badge")).forEach(tag => {
-        tag.setAttribute("aria-label", tag.innerHTML);
-        try {
-            tag.getAttribute("aria-label").split("/").forEach(subtag => tag.classList.add(`tag-${subtag}`))
-        } catch (err) { }
-
-        if (tag.innerHTML.includes("/")) {
-            tag.innerHTML = tag.innerHTML.split('/').slice(1).join('/')
+  var tagFilterListener = function () {
+    // Get filter checkbox status
+    filterTagRoots = []; // Which sections are we filtering on
+    filterTags = []; // Which tags are being selected
+    Array.from(document.getElementsByClassName("tag-filter")).forEach(
+      (checkbox) => {
+        if (checkbox.checked) {
+          let tag = checkbox.getAttribute("id");
+          filterTags.push(checkbox.getAttribute("id"));
+          let root = tag.split("/")[0];
+          if (!filterTagRoots.includes(root)) {
+            filterTagRoots.push(root);
+          }
         }
+      }
+    );
 
-    });
+    // Iterate notebook cards
+    Array.from(document.getElementsByClassName("sd-col")).forEach(
+      (notebook) => {
+        let isFiltered = false;
+
+        // Get tags from the card
+        let tags = [];
+        Array.from(notebook.getElementsByClassName("sd-badge")).forEach(
+          (tag) => {
+            tags.push(tag.getAttribute("aria-label"));
+          }
+        );
+
+        // Iterate each of the sections we are filtering on
+        filterTagRoots.forEach((rootTag) => {
+          // If a notebook has no tags with the current root tag then it is definitely filtered
+          if (
+            !tags.some((tag) => {
+              return tag.startsWith(rootTag);
+            })
+          ) {
+            isFiltered = true;
+          } else {
+            // Get filter tags with the current root we are testing
+            let tagsWithRoot = [];
+            filterTags.forEach((filteredTag) => {
+              if (filteredTag.startsWith(rootTag)) {
+                tagsWithRoot.push(filteredTag);
+              }
+            });
+
+            // If the notebook tags and filter tags don't intersect it is filtered
+            if (!tags.some((item) => tagsWithRoot.includes(item))) {
+              isFiltered = true;
+            }
+          }
+        });
+
+        // Show/hide the card
+        if (isFiltered) {
+          notebook.setAttribute("style", "display:none !important");
+        } else {
+          notebook.setAttribute("style", "display:flex");
+        }
+      }
+    );
+  };
+
+  // Add listener for resetting the filters
+  let resetButton = document.getElementById("resetfilters");
+  if (resetButton != undefined) {
+    resetButton.addEventListener(
+      "click",
+      function () {
+        Array.from(document.getElementsByClassName("tag-filter")).forEach(
+          (checkbox) => {
+            checkbox.checked = false;
+          }
+        );
+        tagFilterListener();
+      },
+      false
+    );
+  }
+
+  // Add listeners to all checkboxes for triggering filtering
+  Array.from(document.getElementsByClassName("tag-filter")).forEach(
+    (checkbox) => {
+      checkbox.addEventListener("change", tagFilterListener, false);
+    }
+  );
+
+  // Simplify tags and add class for styling
+  // It's not possible to control these attributes in Sphinx otherwise we would
+  Array.from(document.getElementsByClassName("sd-badge")).forEach((tag) => {
+    tag.setAttribute("aria-label", tag.innerHTML);
+    try {
+      tag
+        .getAttribute("aria-label")
+        .split("/")
+        .forEach((subtag) => tag.classList.add(`tag-${subtag}`));
+    } catch (err) {}
+
+    if (tag.innerHTML.includes("/")) {
+      tag.innerHTML = tag.innerHTML.split("/").slice(1).join("/");
+    }
+  });
 });

--- a/source/_templates/notebooks-tag-filter.html
+++ b/source/_templates/notebooks-tag-filter.html
@@ -1,22 +1,25 @@
 <nav class="bd-links" id="bd-docs-nav" aria-label="Section navigation">
+  <p class="bd-links__title" role="heading" aria-level="1">
+    Tag filters
+    <small>(<a href="#" id="resetfilters">reset</a>)</small>
+  </p>
 
-    <p class="bd-links__title" role="heading" aria-level="1">
-        Tag filters
-        <small>(<a href="#" id="resetfilters">reset</a>)</small>
-    </p>
-
-    {% for section in sorted(notebook_tag_tree) %}
-    <fieldset aria-level="2" class="caption" role="heading">
-        <legend class="caption-text">{{ section.title() }}</legend>
-        {% for tag in sorted(notebook_tag_tree[section]) %}
-        <div>
-            <input type="checkbox" id="{{section}}/{{ tag }}" class="tag-filter" name="{{ tag }}">
-            <label for="{{ tag }}">
-                <span class="sd-sphinx-override sd-badge">{{section}}/{{ tag }}</span>
-            </label>
-        </div>
-        {% endfor %}
-    </fieldset>
+  {% for section in sorted(notebook_tag_tree) %}
+  <fieldset aria-level="2" class="caption" role="heading">
+    <legend class="caption-text">{{ section.title() }}</legend>
+    {% for tag in sorted(notebook_tag_tree[section]) %}
+    <div>
+      <input
+        type="checkbox"
+        id="{{section}}/{{ tag }}"
+        class="tag-filter"
+        name="{{ tag }}"
+      />
+      <label for="{{ tag }}">
+        <span class="sd-sphinx-override sd-badge">{{section}}/{{ tag }}</span>
+      </label>
+    </div>
     {% endfor %}
-
+  </fieldset>
+  {% endfor %}
 </nav>

--- a/source/_templates/notebooks-tag-filter.html
+++ b/source/_templates/notebooks-tag-filter.html
@@ -1,0 +1,22 @@
+<nav class="bd-links" id="bd-docs-nav" aria-label="Section navigation">
+
+    <p class="bd-links__title" role="heading" aria-level="1">
+        Tag filters
+        <small>(<a href="#" id="resetfilters">reset</a>)</small>
+    </p>
+
+    {% for section in sorted(notebook_tag_tree) %}
+    <fieldset aria-level="2" class="caption" role="heading">
+        <legend class="caption-text">{{ section.title() }}</legend>
+        {% for tag in sorted(notebook_tag_tree[section]) %}
+        <div>
+            <input type="checkbox" id="{{section}}/{{ tag }}" class="tag-filter" name="{{ tag }}">
+            <label for="{{ tag }}">
+                <span class="sd-sphinx-override sd-badge">{{section}}/{{ tag }}</span>
+            </label>
+        </div>
+        {% endfor %}
+    </fieldset>
+    {% endfor %}
+
+</nav>

--- a/source/conf.py
+++ b/source/conf.py
@@ -68,6 +68,11 @@ html_theme_options = {
     ],
 }
 
+html_sidebars = {
+    "**": ["sidebar-nav-bs", "sidebar-ethical-ads"],
+    "index": [],
+    "examples/index": ["notebooks-tag-filter", "sidebar-ethical-ads"],
+}
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
@@ -91,7 +96,9 @@ intersphinx_mapping = {
 
 def setup(app):
     app.add_css_file("https://docs.rapids.ai/assets/css/custom.css")
+    app.add_css_file("css/custom.css")
     app.add_js_file(
         "https://docs.rapids.ai/assets/js/custom.js", loading_method="defer"
     )
     app.add_js_file("js/nav.js", loading_method="defer")
+    app.add_js_file("js/notebook-gallery.js", loading_method="defer")

--- a/source/examples/index.md
+++ b/source/examples/index.md
@@ -4,40 +4,7 @@ html_theme.sidebar_secondary.remove: true
 
 # Workflow Examples
 
-`````{grid} 1 2 2 3
-:gutter: 2 2 2 2
-
-````{grid-item-card}
-:link: xgboost-gpu-hpo-job-parallel-k8s/notebook
-:link-type: doc
-XGBoost HPO
-^^^
-Scaling up hyperparameter optimization with Kubernetes and XGBoost GPU algorithm
-
-{bdg-primary}`Dask`
-{bdg-primary}`XGBoost`
-{bdg-primary}`Kubernetes`
-````
-
-````{grid-item-card}
-:link: rapids-sagemaker-higgs/notebook
-:link-type: doc
-HPO on Sagemaker with cuML
-^^^
-Running RAPIDS hyperparameter experiments at scale on Amazon SageMaker
-
-{bdg-primary}`cuML`
-{bdg-primary}`Sagemaker`
-{bdg-primary}`AWS`
-````
-
-`````
-
-```{toctree}
-:maxdepth: 2
-:caption: Workflow Examples
-:hidden:
-
+```{notebookgallerytoctree}
 xgboost-gpu-hpo-job-parallel-k8s/notebook
 rapids-sagemaker-higgs/notebook
 ```

--- a/source/examples/rapids-sagemaker-higgs/notebook.ipynb
+++ b/source/examples/rapids-sagemaker-higgs/notebook.ipynb
@@ -5,7 +5,10 @@
             "metadata": {
                 "tags": [
                     "cloud/aws/sagemaker",
-                    "workflow/hpo"
+                    "workflow/hpo",
+                    "library/cudf",
+                    "library/cuml",
+                    "library/scikit-learn"
                 ]
             },
             "source": [

--- a/source/examples/xgboost-gpu-hpo-job-parallel-k8s/notebook.ipynb
+++ b/source/examples/xgboost-gpu-hpo-job-parallel-k8s/notebook.ipynb
@@ -1,11 +1,31 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "45684b2f-019b-4ccf-af65-b722aa270e40",
+   "metadata": {
+    "tags": [
+     "library/xgboost",
+     "library/optuna",
+     "library/dask",
+     "tool/dask-kubernetes",
+     "platform/kubernetes",
+     "platform/kubeflow",
+     "library/scikit-learn",
+     "workflow/hpo"
+    ]
+   },
+   "source": [
+    "# Scaling up hyperparameter optimization with Kubernetes and XGBoost GPU algorithm"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "6286d640",
    "metadata": {},
    "source": [
-    "# Scaling up hyperparameter optimization with Kubernetes and XGBoost GPU algorithm\n",
     "\n",
     "Choosing an optimal set of hyperparameters is a daunting task, especially for algorithms like XGBoost that have many hyperparameters to tune. In this notebook, we will show how to speed up hyperparameter optimization by running multiple training jobs in parallel on a Kubernetes cluster.\n",
     "\n",
@@ -795,7 +815,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10 (default, Jun 22 2022, 20:18:18) \n[GCC 9.4.0]"
+   "version": "3.9.6 (default, Aug  5 2022, 15:21:02) \n[Clang 14.0.0 (clang-1400.0.29.102)]"
   },
   "vscode": {
    "interpreter": {

--- a/source/guides/index.md
+++ b/source/guides/index.md
@@ -14,8 +14,8 @@ Multi-Instance GPUs
 ^^^
 Use RAPIDS with Multi-Instance GPUs
 
-{bdg-primary}`Dask Cluster`
-{bdg-primary}`XGBoost with Dask Cluster`
+{bdg}`Dask Cluster`
+{bdg}`XGBoost with Dask Cluster`
 ````
 
 ````{grid-item-card}
@@ -25,7 +25,7 @@ Infiniband on Azure
 ^^^
 How to setup InfiniBand on Azure.
 
-{bdg-primary}`Microsoft Azure`
+{bdg}`Microsoft Azure`
 ````
 
 `````

--- a/source/index.md
+++ b/source/index.md
@@ -16,10 +16,10 @@ Deployment documentation to get you up and running with RAPIDS anywhere.
 ^^^
 Use RAPIDS on your local workstation or server.
 
-{bdg-primary}`docker`
-{bdg-primary}`conda`
-{bdg-primary}`pip`
-{bdg-primary}`WSL2`
+{bdg}`docker`
+{bdg}`conda`
+{bdg}`pip`
+{bdg}`WSL2`
 ````
 
 ````{grid-item-card}
@@ -29,10 +29,10 @@ Use RAPIDS on your local workstation or server.
 ^^^
 Use RAPIDS on the cloud.
 
-{bdg-primary}`Amazon Web Services`
-{bdg-primary}`Google Cloud Platform`
-{bdg-primary}`Microsoft Azure`
-{bdg-primary}`IBM Cloud`
+{bdg}`Amazon Web Services`
+{bdg}`Google Cloud Platform`
+{bdg}`Microsoft Azure`
+{bdg}`IBM Cloud`
 ````
 
 ````{grid-item-card}
@@ -42,7 +42,7 @@ Use RAPIDS on the cloud.
 ^^^
 Use RAPIDS on high performance computers and supercomputers.
 
-{bdg-primary}`SLURM`
+{bdg}`SLURM`
 ````
 
 ````{grid-item-card}
@@ -52,10 +52,10 @@ Use RAPIDS on high performance computers and supercomputers.
 ^^^
 Use RAPIDS on compute platforms.
 
-{bdg-primary}`Kubernetes`
-{bdg-primary}`Kubeflow`
-{bdg-primary}`Coiled`
-{bdg-primary}`Databricks`
+{bdg}`Kubernetes`
+{bdg}`Kubeflow`
+{bdg}`Coiled`
+{bdg}`Databricks`
 ````
 
 ````{grid-item-card}
@@ -65,11 +65,11 @@ Use RAPIDS on compute platforms.
 ^^^
 There are many tools to deploy RAPIDS.
 
-{bdg-primary}`containers`
-{bdg-primary}`dask-kubernetes`
-{bdg-primary}`dask-operator`
-{bdg-primary}`dask-helm-chart`
-{bdg-primary}`dask-gateway`
+{bdg}`containers`
+{bdg}`dask-kubernetes`
+{bdg}`dask-operator`
+{bdg}`dask-helm-chart`
+{bdg}`dask-gateway`
 ````
 
 ````{grid-item-card}
@@ -78,10 +78,10 @@ There are many tools to deploy RAPIDS.
 ^^^
 For inspiration see our example notebooks with opinionated deployments of RAPIDS to boost machine learning workflows.
 
-{bdg-primary}`xgboost`
-{bdg-primary}`optuna`
-{bdg-primary}`mlflow`
-{bdg-primary}`ray tune`
+{bdg}`xgboost`
+{bdg}`optuna`
+{bdg}`mlflow`
+{bdg}`ray tune`
 ````
 
 ````{grid-item-card}
@@ -91,9 +91,9 @@ For inspiration see our example notebooks with opinionated deployments of RAPIDS
 ^^^
 Detailed guides on how to deploy and optimize RAPIDS.
 
-{bdg-primary}`Microsoft Azure`
-{bdg-primary}`Infiniband`
-{bdg-primary}`MIG`
+{bdg}`Microsoft Azure`
+{bdg}`Infiniband`
+{bdg}`MIG`
 ````
 `````
 

--- a/source/platforms/index.md
+++ b/source/platforms/index.md
@@ -10,8 +10,8 @@ Kubernetes
 ^^^
 Launch RAPIDS containers and cluster on Kubernetes with various tools.
 
-{bdg-primary}`single-node`
-{bdg-primary}`multi-node`
+{bdg}`single-node`
+{bdg}`multi-node`
 ````
 
 ````{grid-item-card}
@@ -21,8 +21,8 @@ Kubeflow
 ^^^
 Integrate RAPIDS with Kubeflow notebooks and pipelines.
 
-{bdg-primary}`single-node`
-{bdg-primary}`multi-node`
+{bdg}`single-node`
+{bdg}`multi-node`
 ````
 
 ````{grid-item-card}
@@ -32,7 +32,7 @@ Coiled
 ^^^
 Run RAPIDS on Coiled.
 
-{bdg-primary}`multi-node`
+{bdg}`multi-node`
 ````
 
 `````


### PR DESCRIPTION
Closes #106. With this PR the example notebooks are shown in a gallery and can be filtered by their tags.

<img width="1336" alt="image" src="https://user-images.githubusercontent.com/1610850/215108861-d7ed0722-b9d1-4b4f-9424-e783c684b1fb.png">

This change is made up of a few pieces:

- A custom toctree directive which generates a card table using the same notebook card generator from #111 
  - _NB this approach would be useful for closing #115 in a follow up PR_
- A custom sidebar template for the examples index page with filtering checkboxes generated from the tag tree
- Some client-side JavaScript that hides/shows notebook cards based on the filter checkboxes
- Some custom CSS which styles the filter sidebar and colours the tags
- I changed the tag style from `bdg-primary` to `bdg` throughout the site so the custom tag styling would work correctly on all pages