### PR TITLE
Add notebook tag sidebar

### DIFF
--- a/extensions/rapids_related_examples.py
+++ b/extensions/rapids_related_examples.py
@@ -144,6 +144,9 @@ def add_notebook_tag_map_to_context(app, pagename, templatename, context, doctre
         except KeyError:
             tag_tree[root] = [suffix]
     context["notebook_tag_tree"] = tag_tree
+    context["notebook_tags"] = [
+        tag for tag, pages in app.env.notebook_tag_map.items() if pagename in pages
+    ]
 
 
 class NotebookGalleryTocTree(TocTree):

--- a/source/_static/css/custom.css
+++ b/source/_static/css/custom.css
@@ -18,6 +18,10 @@ nav.bd-links fieldset .sd-badge {
   font-size: 0.9em;
 }
 
+.tagwrapper {
+  margin-top: 0.25em;
+}
+
 /* Tag colours */
 .sd-badge {
   /* Defaults */

--- a/source/_static/js/notebook-gallery.js
+++ b/source/_static/js/notebook-gallery.js
@@ -1,4 +1,37 @@
 document.addEventListener("DOMContentLoaded", function () {
+  var setURLFilters = function (filters) {
+    var newAdditionalURL = "";
+    var tempArray = window.location.href.split("?");
+    var baseURL = tempArray[0];
+    var additionalURL = tempArray[1];
+    var temp = "";
+    if (additionalURL) {
+      tempArray = additionalURL.split("&");
+      for (var i = 0; i < tempArray.length; i++) {
+        if (tempArray[i].split("=")[0] != "filters") {
+          newAdditionalURL += temp + tempArray[i];
+          temp = "&";
+        }
+      }
+    }
+    if (filters.length) {
+      newAdditionalURL += temp + "filters=" + filters.join(",");
+    }
+    if (newAdditionalURL) {
+      window.history.replaceState("", "", baseURL + "?" + newAdditionalURL);
+    } else {
+      window.history.replaceState("", "", baseURL);
+    }
+  };
+
+  var getUrlFilters = function () {
+    let search = new URLSearchParams(window.location.search);
+    let filters = search.get("filters");
+    if (filters) {
+      return filters.split(",");
+    }
+  };
+
   var tagFilterListener = function () {
     // Get filter checkbox status
     filterTagRoots = []; // Which sections are we filtering on
@@ -15,6 +48,8 @@ document.addEventListener("DOMContentLoaded", function () {
         }
       }
     );
+
+    setURLFilters(filterTags);
 
     // Iterate notebook cards
     Array.from(document.getElementsByClassName("sd-col")).forEach(
@@ -103,4 +138,17 @@ document.addEventListener("DOMContentLoaded", function () {
       tag.innerHTML = tag.innerHTML.split("/").slice(1).join("/");
     }
   });
+
+  // Set checkboxes initial state
+  var initFilters = getUrlFilters();
+  if (initFilters) {
+    Array.from(document.getElementsByClassName("tag-filter")).forEach(
+      (checkbox) => {
+        if (initFilters.includes(checkbox.id)) {
+          checkbox.checked = true;
+        }
+      }
+    );
+    tagFilterListener();
+  }
 });

--- a/source/_templates/notebooks-tags.html
+++ b/source/_templates/notebooks-tags.html
@@ -1,0 +1,10 @@
+{% if notebook_tags %}
+<div class="tocsection onthispage"><i class="fa-solid fa-tags"></i> Tags</div>
+<nav id="bd-toc-nav" class="page-toc">
+  <div class="tagwrapper">
+    {% for tag in notebook_tags %}
+    <span class="sd-sphinx-override sd-badge">{{ tag }}</span>
+    {% endfor %}
+  </div>
+</nav>
+{% endif %}

--- a/source/_templates/notebooks-tags.html
+++ b/source/_templates/notebooks-tags.html
@@ -3,7 +3,9 @@
 <nav id="bd-toc-nav" class="page-toc">
   <div class="tagwrapper">
     {% for tag in notebook_tags %}
-    <span class="sd-sphinx-override sd-badge">{{ tag }}</span>
+    <a href="../?filters={{ tag }}">
+      <span class="sd-sphinx-override sd-badge">{{ tag }}</span>
+    </a>
     {% endfor %}
   </div>
 </nav>

--- a/source/conf.py
+++ b/source/conf.py
@@ -65,6 +65,7 @@ html_theme_options = {
     "secondary_sidebar_items": [
         "page-toc",
         "notebooks-extra-files-nav",
+        "notebooks-tags",
     ],
 }
 


### PR DESCRIPTION
Add notebook tags visibly on the notebook page. Closes #109. 

I went with a sidebar for displaying the tags as it was much easier to implement than plugging into the MyST-NB parser.

<img width="996" alt="image" src="https://user-images.githubusercontent.com/1610850/215475996-3288a1e9-0bdb-4346-baf8-63324feead7a.png">

I also updated the examples gallery so that when you check the filter boxes it updates the URL with a query parameter. Then on page load it looks for any tags in the URL and updates the checkboxes initial state. This allows us to link to the examples gallery with filters already checked.

<img width="1129" alt="image" src="https://user-images.githubusercontent.com/1610850/215476492-a3c69923-8b39-4cec-a214-de4495e4d200.png">

I then made the tags on the notebook pages links to the gallery with that tag already filtered.

https://github.com/rapidsai/deployment/blob/ea9dac887a0c164e4fb2450d3f016f2ce3eb84ac/source/_templates/notebooks-tags.html#L6-L8