### PR TITLE
Fix duplicated entries in examples sidebar section nav

### DIFF
--- a/extensions/rapids_related_examples.py
+++ b/extensions/rapids_related_examples.py
@@ -148,7 +148,8 @@ def add_notebook_tag_map_to_context(app, pagename, templatename, context, doctre
 
 class NotebookGalleryTocTree(TocTree):
     def run(self) -> list[nodes.Node]:
-        output = nodes.section(ids=["examplegallery"])
+        output = nodes.container()
+        gallery = nodes.section(ids=["examplegallery"])
 
         # Generate the actual toctree but ensure it is hidden
         self.options["hidden"] = True
@@ -161,8 +162,9 @@ class NotebookGalleryTocTree(TocTree):
         ]
         grid_markdown = generate_notebook_grid_myst(notebooks=notebooks, env=self.env)
         for node in parse_markdown(markdown=grid_markdown, state=self.state):
-            output += node
+            gallery += node
 
+        output += gallery
         return [output]
 
 


### PR DESCRIPTION
Fixes #120.

It seems that putting `toctree` nodes inside a `nodes.section` node causes this duplicating behaviour. No idea why. Putting both the `section` and the hidden `toctree` inside a top-level `nodes.container` node resolves it 🤷‍♂️.

```
# bad
section
├── other stuff
└── toctree

# good
container
├── section
│   └── other stuff
└── toctree
```

<img width="1098" alt="image" src="https://user-images.githubusercontent.com/1610850/215501868-5187072c-6053-41f2-ab11-b77857dc46dd.png">
