### PR TITLE
Add Grid Toctree custom directive

### DIFF
--- a/extensions/rapids_card_toctree.py
+++ b/extensions/rapids_card_toctree.py
@@ -1,9 +1,17 @@
-
 from docutils import nodes
 from docutils.statemachine import ViewList
 from sphinx.application import Sphinx
 from sphinx.directives.other import TocTree
 from sphinx.util.nodes import nested_parse_with_titles
+
+
+def find_linked_documents(node):
+    for child in node.traverse():
+        try:
+            if child.attributes["reftarget"]:
+                yield child.attributes["reftarget"]
+        except (AttributeError, KeyError):
+            pass
 
 
 class CardGridTocTree(TocTree):
@@ -26,13 +34,8 @@ class CardGridTocTree(TocTree):
         nested_parse_with_titles(self.state, content, grid)
         output += grid
 
-        # Update the content with the document names ready for toctree generation
-        # TODO get the doc names from walking the grid nodes rather than manipulating the markdown
-        self.content.data = [
-            line.replace(":link:", "").strip()
-            for line in self.content.data
-            if ":link:" in line
-        ]
+        # Update the content with the document names referenced in the card grid ready for toctree generation
+        self.content.data = [doc for doc in find_linked_documents(grid)]
 
         # Generate the actual toctree but ensure it is hidden
         self.options["hidden"] = True

--- a/extensions/rapids_card_toctree.py
+++ b/extensions/rapids_card_toctree.py
@@ -1,0 +1,52 @@
+
+from docutils import nodes
+from docutils.statemachine import ViewList
+from sphinx.application import Sphinx
+from sphinx.directives.other import TocTree
+from sphinx.util.nodes import nested_parse_with_titles
+
+
+class CardGridTocTree(TocTree):
+    # TODO Enable configuring all grid options and arguments
+    # https://sphinx-design.readthedocs.io/en/latest/grids.html#grid-options
+    # This probably would require changing this class to inherit from ``sphinx_design.grids.GridDirective``
+    # and instantiating the TocTree class part way through and ensuring it is configured well enough
+    # to call run.
+
+    def run(self) -> list[nodes.Node]:
+        output = nodes.container()
+
+        # Generate the card grid
+        grid = nodes.section(ids=["toctreegrid"])
+        # TODO Stop manipulating markdown here
+        content = ViewList(
+            ["`````{grid} 1 2 2 3", ":gutter: 2 2 2 2"] + self.content.data + ["`````"],
+            "fakefile.md",
+        )
+        nested_parse_with_titles(self.state, content, grid)
+        output += grid
+
+        # Update the content with the document names ready for toctree generation
+        # TODO get the doc names from walking the grid nodes rather than manipulating the markdown
+        self.content.data = [
+            line.replace(":link:", "").strip()
+            for line in self.content.data
+            if ":link:" in line
+        ]
+
+        # Generate the actual toctree but ensure it is hidden
+        self.options["hidden"] = True
+        toctree = super().run()
+        output += toctree
+
+        return [output]
+
+
+def setup(app: Sphinx) -> dict:
+    app.add_directive("cardgridtoctree", CardGridTocTree)
+
+    return {
+        "version": "0.1",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/extensions/rapids_grid_toctree.py
+++ b/extensions/rapids_grid_toctree.py
@@ -7,6 +7,11 @@ from sphinx_design.grids import GridDirective
 
 
 def find_linked_documents(node):
+    """Find all referenced documents in a node tree.
+
+    Walks the nodes and yield the reftarget attribute for any that have it set.
+
+    """
     for child in node.traverse():
         try:
             if child.attributes["reftarget"]:
@@ -16,6 +21,13 @@ def find_linked_documents(node):
 
 
 class CardGridTocTree(GridDirective):
+    """An extension of sphinx_design.grids.GridDirective that also add referenced docs to the toctree.
+
+    For any element within the grid which links to another page with the ``link-type`` ``doc`` the
+    doc gets added to the toctree of that page.
+
+    """
+
     def run(self) -> list[nodes.Node]:
         output = nodes.container()
 
@@ -37,7 +49,7 @@ class CardGridTocTree(GridDirective):
 
 
 def setup(app: Sphinx) -> dict:
-    app.add_directive("cardgridtoctree", CardGridTocTree)
+    app.add_directive("gridtoctree", CardGridTocTree)
 
     return {
         "version": "0.1",

--- a/source/conf.py
+++ b/source/conf.py
@@ -35,7 +35,7 @@ extensions = [
     "sphinx_copybutton",
     "rapids_notebook_files",
     "rapids_related_examples",
-    "rapids_card_toctree",
+    "rapids_grid_toctree",
 ]
 
 myst_enable_extensions = ["colon_fence"]

--- a/source/conf.py
+++ b/source/conf.py
@@ -35,6 +35,7 @@ extensions = [
     "sphinx_copybutton",
     "rapids_notebook_files",
     "rapids_related_examples",
+    "rapids_card_toctree",
 ]
 
 myst_enable_extensions = ["colon_fence"]

--- a/source/guides/index.md
+++ b/source/guides/index.md
@@ -4,7 +4,7 @@ html_theme.sidebar_secondary.remove: true
 
 # Guides
 
-`````{grid} 1 2 2 3
+`````{gridtoctree} 1 2 2 3
 :gutter: 2 2 2 2
 
 ````{grid-item-card}
@@ -29,12 +29,3 @@ How to setup InfiniBand on Azure.
 ````
 
 `````
-
-```{toctree}
-:maxdepth: 2
-:caption: Guides
-:hidden:
-
-mig
-azure/infiniband
-```

--- a/source/index.md
+++ b/source/index.md
@@ -6,7 +6,7 @@ html_theme.sidebar_secondary.remove: true
 
 Deployment documentation to get you up and running with RAPIDS anywhere.
 
-`````{grid} 1 2 2 3
+`````{gridtoctree} 1 2 2 3
 :gutter: 2 2 2 2
 
 ````{grid-item-card}
@@ -73,7 +73,8 @@ There are many tools to deploy RAPIDS.
 ````
 
 ````{grid-item-card}
-:link: examples
+:link: examples/index
+:link-type: doc
 {fas}`book;sd-text-primary` Workflow examples
 ^^^
 For inspiration see our example notebooks with opinionated deployments of RAPIDS to boost machine learning workflows.
@@ -96,31 +97,3 @@ Detailed guides on how to deploy and optimize RAPIDS.
 {bdg}`MIG`
 ````
 `````
-
-```{toctree}
-:maxdepth: 3
-:hidden:
-:caption: Deploy RAPIDS on
-
-local
-cloud/index
-hpc
-platforms/index
-guides/index
-```
-
-```{toctree}
-:maxdepth: 3
-:hidden:
-:caption: Deploy RAPIDS with
-
-tools/index
-```
-
-```{toctree}
-:maxdepth: 3
-:hidden:
-:caption: Examples
-
-examples/index
-```

--- a/source/platforms/index.md
+++ b/source/platforms/index.md
@@ -1,6 +1,7 @@
 # Platforms
 
-`````{cardgridtoctree}
+`````{cardgridtoctree} 1 2 2 3
+:gutter: 2 2 2 2
 
 ````{grid-item-card}
 :link: kubernetes

--- a/source/platforms/index.md
+++ b/source/platforms/index.md
@@ -1,7 +1,6 @@
 # Platforms
 
-`````{grid} 1 2 2 3
-:gutter: 2 2 2 2
+`````{cardgridtoctree}
 
 ````{grid-item-card}
 :link: kubernetes
@@ -36,13 +35,3 @@ Run RAPIDS on Coiled.
 ````
 
 `````
-
-```{toctree}
-:maxdepth: 2
-:caption: Platforms
-:hidden:
-
-kubernetes
-kubeflow
-coiled
-```

--- a/source/platforms/index.md
+++ b/source/platforms/index.md
@@ -1,6 +1,10 @@
+---
+html_theme.sidebar_secondary.remove: true
+---
+
 # Platforms
 
-`````{cardgridtoctree} 1 2 2 3
+`````{gridtoctree} 1 2 2 3
 :gutter: 2 2 2 2
 
 ````{grid-item-card}

--- a/source/tools/index.md
+++ b/source/tools/index.md
@@ -2,7 +2,7 @@
 
 ## Packages
 
-`````{grid} 1 2 2 3
+`````{gridtoctree} 1 2 2 3
 :gutter: 2 2 2 2
 
 ````{grid-item-card}
@@ -17,7 +17,7 @@ Container images containing the RAPIDS software environment.
 
 ## Kubernetes
 
-`````{grid} 1 2 2 3
+`````{gridtoctree} 1 2 2 3
 :gutter: 2 2 2 2
 
 ````{grid-item-card}
@@ -45,14 +45,3 @@ Install a single user notebook and cluster on Kubernetes with the Dask Helm Char
 ````
 
 `````
-
-```{toctree}
-:hidden:
-:maxdepth: 2
-:caption: Tools
-
-rapids-docker
-kubernetes/dask-kubernetes
-kubernetes/dask-operator
-kubernetes/dask-helm-chart
-```


### PR DESCRIPTION
On many index pages we display a grid of cards for navigation because they look nicer than the default toctree bullet list

<img width="1323" alt="image" src="https://user-images.githubusercontent.com/1610850/215530930-18758d99-a834-4d41-964e-d76bf12f7607.png">

However we still have to include the hidden toctree element on each page to ensure the Sphinx navigation is generated correctly.

For example in `source/guides/index.md` we have the card grid for navigation.

https://github.com/rapidsai/deployment/blob/18280348ab1648855ff7e076b4d76f419ae9734e/source/guides/index.md?plain=1#L7-L31

And the hidden toctree with the same entries.

https://github.com/rapidsai/deployment/blob/18280348ab1648855ff7e076b4d76f419ae9734e/source/guides/index.md?plain=1#L33-L40

This PR adds a custom directive called `gridtoctree` which extends the [`grid` from sphinx-design](https://sphinx-design.readthedocs.io/en/latest/grids.html#grids) to automatically add all referenced documents to the toctree. This means we can replace `{grid}` with `{gridtoctree}` in many places and delete the duplicated `{toctree}` section altogether.

The only place where I haven't done this for now is the cloud pages because they use an include to show the card grid on both the cloud index and the index of each cloud provider. We don't want the toctree to be applied to both of those. I'll open an issue to track fixing this in a followup.

Closes #115 