### PR TITLE
Add black to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,12 @@ repos:
         # pre-commit's default_language_version, see
         # https://pre-commit.com/#top_level-default_language_version
         language_version: python3.9
+  - repo: https://github.com/adamchainz/blacken-docs
+    rev: 1.13.0 # replace with latest tag on GitHub
+    hooks:
+      - id: blacken-docs
+        additional_dependencies:
+          - black==23.1.0
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: "v2.5.1" # Use the sha or tag you want to point at
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,15 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
+  - repo: https://github.com/psf/black
+    rev: 23.1.0
+    hooks:
+      - id: black-jupyter
+        # It is recommended to specify the latest version of Python
+        # supported by your project here, or alternatively use
+        # pre-commit's default_language_version, see
+        # https://pre-commit.com/#top_level-default_language_version
+        language_version: python3.9
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: "v2.5.1" # Use the sha or tag you want to point at
     hooks:

--- a/source/_includes/test-rapids-docker-vm.md
+++ b/source/_includes/test-rapids-docker-vm.md
@@ -1,6 +1,6 @@
 In the terminal we can open `ipython` and check that we can import and use RAPIDS libraries like `cudf`.
 
-```python
+```ipython
 In [1]: import cudf
 In [2]: df = cudf.datasets.timeseries()
 In [3]: df.head()

--- a/source/cloud/aws/ecs.md
+++ b/source/cloud/aws/ecs.md
@@ -65,10 +65,10 @@ Create the ECSCluster object in your Python session:
 
 ```python
 from dask_cloudprovider.aws import ECSCluster
-cluster = ECSCluster(cluster_arn=[CLUSTER_ARN],
-                     n_workers=[NUM_WORKERS],
-                     worker_gpu=[NUM_GPUS]
-                     )
+
+cluster = ECSCluster(
+    cluster_arn=[CLUSTER_ARN], n_workers=[NUM_WORKERS], worker_gpu=[NUM_GPUS]
+)
 ```
 
 [CLUSTER_ARN] = The ARN of an existing ECS cluster to use for launching tasks <br />
@@ -79,6 +79,7 @@ cluster = ECSCluster(cluster_arn=[CLUSTER_ARN],
 
 ```python
 from dask.distributed import Client
+
 client = Client(cluster)
 ```
 
@@ -86,9 +87,10 @@ Load sample data and test the cluster!
 
 ```python
 import dask, cudf, dask_cudf
+
 ddf = dask.datasets.timeseries()
 gdf = ddf.map_partitions(cudf.from_pandas)
-gdf.groupby('name').id.count().compute().head()
+gdf.groupby("name").id.count().compute().head()
 ```
 
 ```shell

--- a/source/cloud/azure/azure-vm-multi.md
+++ b/source/cloud/azure/azure-vm-multi.md
@@ -22,6 +22,7 @@ In Python terminal, a cluster can be created using the `dask_cloudprovider` pack
 
 ```python
 from dask_cloudprovider.azure import AzureVMCluster
+
 resource_group = "<RESOURCE_GROUP>"
 vnet = "<VNET>"
 security_group = "<SECURITY_GROUP>"
@@ -48,12 +49,17 @@ To test RAPIDS, create a distributed client for the cluster and query for the GP
 
 ```python
 from dask.distributed import Client
+
 client = Client(cluster)
 
+
 def get_gpu_model():
-   import pynvml
-   pynvml.nvmlInit()
-   return pynvml.nvmlDeviceGetName(pynvml.nvmlDeviceGetHandleByIndex(0))
+    import pynvml
+
+    pynvml.nvmlInit()
+    return pynvml.nvmlDeviceGetName(pynvml.nvmlDeviceGetHandleByIndex(0))
+
+
 client.submit(get_gpu_model).result()
 ```
 

--- a/source/cloud/gcp/vertex-ai.md
+++ b/source/cloud/gcp/vertex-ai.md
@@ -36,10 +36,11 @@ Once the managed notebook is fully configured, you can click **OPEN JUPYTERLAB**
 
 For example we could import and use RAPIDS libraries like `cudf`.
 
-```python
-import cudf
-df = cudf.datasets.timeseries()
-df.head()
+```ipython
+In [1]: import cudf
+In [2]: df = cudf.datasets.timeseries()
+In [3]: df.head()
+Out[3]:
                        id     name         x         y
 timestamp
 2000-01-01 00:00:00  1020    Kevin  0.091536  0.664482

--- a/source/examples/rapids-sagemaker-higgs/notebook.ipynb
+++ b/source/examples/rapids-sagemaker-higgs/notebook.ipynb
@@ -1,433 +1,448 @@
 {
-    "cells": [
-        {
-            "cell_type": "markdown",
-            "metadata": {
-                "tags": [
-                    "cloud/aws/sagemaker",
-                    "workflow/hpo",
-                    "library/cudf",
-                    "library/cuml",
-                    "library/scikit-learn"
-                ]
-            },
-            "source": [
-                "# Running RAPIDS hyperparameter experiments at scale on Amazon SageMaker"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "### Import packages and create Amazon SageMaker and Boto3 sessions"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {
-                "tags": []
-            },
-            "outputs": [],
-            "source": [
-                "import sagemaker\n",
-                "import time\n",
-                "import boto3"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "execution_role = sagemaker.get_execution_role()\n",
-                "session = sagemaker.Session()\n",
-                "\n",
-                "region = boto3.Session().region_name\n",
-                "account = boto3.client('sts').get_caller_identity().get('Account')"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "account, region"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "### Upload the higgs-boson dataset to s3 bucket"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "!mkdir dataset\n",
-                "!wget -P dataset https://archive.ics.uci.edu/ml/machine-learning-databases/00280/HIGGS.csv.gz\n",
-                "!gunzip dataset/HIGGS.csv.gz"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "s3_data_dir = session.upload_data(path='dataset', key_prefix='dataset/higgs-dataset')"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "s3_data_dir"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {
-                "tags": []
-            },
-            "source": [
-                "### Download latest RAPIDS container with cloud-ml examples\n",
-                "\n",
-                "Extend the container by copying the training script and installing [SageMaker Training toolkit](https://github.com/aws/sagemaker-training-toolkit) to makes RAPIDS compatible with SageMaker"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "# estimator_info = {\n",
-                "#     'rapids_container': 'rapidsai/rapidsai-cloud-ml:latest',\n",
-                "#     'ecr_image': 'sagemaker-rapids-cloud-ml:latest',\n",
-                "#     'ecr_repository': 'sagemaker-rapids-cloud-ml'\n",
-                "# }"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "estimator_info = {\n",
-                "    'rapids_container':'rapidsai/rapidsai-nightly:22.12-cuda11.5-runtime-ubuntu18.04-py3.9',\n",
-                "    'ecr_image':'sagemaker-rapids-nightly',\n",
-                "    'ecr_repository':'sagemaker-rapids-nightly'\n",
-                "}"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "%%time\n",
-                "!docker pull {estimator_info['rapids_container']}"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "!cat docker/Dockerfile"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "#FROM rapidsai/rapidsai-cloud-ml:latest\n",
-                "#!docker build -t sagemaker-rapids:latest docker"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "!docker build -t sagemaker-rapids-nightly docker"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "!docker images"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "### Publish to Elastic Container Registry"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "Note: SageMaker does not support using training images from private docker registry (ie. DockerHub), so we need to push\n",
-                "the SageMaker-compatible \\\n",
-                "RAPIDS container to the Amazon Elastic Container Registry."
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "ECR_container_fullname = f\"{account}.dkr.ecr.{region}.amazonaws.com/{estimator_info['ecr_image']}\""
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "ECR_container_fullname "
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "!docker tag {estimator_info['rapids_container']} {ECR_container_fullname}"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "print( f\"source      : {estimator_info['rapids_container']}\\n\"\n",
-                "       f\"destination : {ECR_container_fullname}\")"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "!docker images"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "!aws ecr create-repository --repository-name {estimator_info['ecr_repository']}\n",
-                "!$(aws ecr get-login --no-include-email --region {region})"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "!docker push {ECR_container_fullname}"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "##### Define hyperparameters: start with best guess values\n",
-                "Find the full list of Random Forest hyperparameters here in the RAPIDS doc page:\n",
-                "<br>\n",
-                "https://docs.rapids.ai/api/cuml/stable/api.html#random-forest"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "hyperparams={ \n",
-                "    'n_estimators'       : 15,\n",
-                "    'max_depth'          : 5,\n",
-                "    'n_bins'             : 8,\n",
-                "    'split_criterion'    : 0,      # GINI:0, ENTROPY:1\n",
-                "    'bootstrap'          : 0,      # true: sample with replacement, false: sample without replacement\n",
-                "    'max_leaves'         : -1,     # unlimited leaves\n",
-                "    'max_features'       : 0.2, \n",
-                "}"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "from sagemaker.estimator import Estimator\n",
-                "\n",
-                "rapids_estimator = Estimator(image_uri=ECR_container_fullname,\n",
-                "                          role=execution_role,\n",
-                "                          instance_count=1,\n",
-                "                          instance_type='ml.g4dn.4xlarge',\n",
-                "                          hyperparameters=hyperparams,\n",
-                "                          metric_definitions=[{'Name': 'test_acc', 'Regex': 'test_acc: ([0-9\\\\.]+)'}])"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "%%time\n",
-                "rapids_estimator.fit(inputs = s3_data_dir)"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "from sagemaker.tuner import IntegerParameter, CategoricalParameter, ContinuousParameter, HyperparameterTuner\n",
-                "\n",
-                "hyperparameter_ranges = {\n",
-                "    'n_estimators'        : IntegerParameter(10, 200), \n",
-                "    'max_depth'           : IntegerParameter(1, 22),\n",
-                "    'n_bins'              : IntegerParameter(5, 24),\n",
-                "    'split_criterion'     : CategoricalParameter([0, 1]),\n",
-                "    'bootstrap'           : CategoricalParameter([True, False]),\n",
-                "    'max_features'        : ContinuousParameter(0.01, 0.5),\n",
-                "}"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "from sagemaker.estimator import Estimator\n",
-                "\n",
-                "rapids_estimator = Estimator(image_uri=image,\n",
-                "                          role=execution_role,\n",
-                "                          instance_count=1,\n",
-                "                          instance_type='ml.p3.2xlarge',\n",
-                "                          hyperparameters=hyperparams,\n",
-                "                          metric_definitions=[{'Name': 'test_acc', 'Regex': 'test_acc: ([0-9\\\\.]+)'}])"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "tuner = HyperparameterTuner(rapids_estimator,\n",
-                "                            objective_metric_name='test_acc',\n",
-                "                            hyperparameter_ranges=hyperparameter_ranges,\n",
-                "                            strategy='Bayesian',\n",
-                "                            max_jobs=1,\n",
-                "                            max_parallel_jobs=1,\n",
-                "                            objective_type='Maximize',\n",
-                "                            metric_definitions=[{'Name': 'test_acc', 'Regex': 'test_acc: ([0-9\\\\.]+)'}])"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "job_name = 'rapidsHPO' + time.strftime('%Y-%m-%d-%H-%M-%S-%j', time.gmtime())\n",
-                "tuner.fit({'dataset': s3_data_dir}, job_name=job_name)"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": []
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "## Clean up"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "- Delete S3 buckets and files you don't need\n",
-                "- Kill training jobs that you don't want running\n",
-                "- Delete container images and the repository you just created"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "aws ecr delete-repository --force --repository-name"
-            ]
-        }
-    ],
-    "metadata": {
-        "kernelspec": {
-            "display_name": "deployment-docs-dev",
-            "language": "python",
-            "name": "python3"
-        },
-        "language_info": {
-            "codemirror_mode": {
-                "name": "ipython",
-                "version": 3
-            },
-            "file_extension": ".py",
-            "mimetype": "text/x-python",
-            "name": "python",
-            "nbconvert_exporter": "python",
-            "pygments_lexer": "ipython3",
-            "version": "3.9.13 | packaged by conda-forge | (main, May 27 2022, 16:58:50) \n[GCC 10.3.0]"
-        },
-        "vscode": {
-            "interpreter": {
-                "hash": "f8a5d5d9459d186eb4ada656f03b674a34a7efd585f7a94c29caa9bfea516aa8"
-            }
-        }
-    },
-    "nbformat": 4,
-    "nbformat_minor": 4
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "cloud/aws/sagemaker",
+     "workflow/hpo",
+     "library/cudf",
+     "library/cuml",
+     "library/scikit-learn"
+    ]
+   },
+   "source": [
+    "# Running RAPIDS hyperparameter experiments at scale on Amazon SageMaker"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Import packages and create Amazon SageMaker and Boto3 sessions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import sagemaker\n",
+    "import time\n",
+    "import boto3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "execution_role = sagemaker.get_execution_role()\n",
+    "session = sagemaker.Session()\n",
+    "\n",
+    "region = boto3.Session().region_name\n",
+    "account = boto3.client(\"sts\").get_caller_identity().get(\"Account\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "account, region"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Upload the higgs-boson dataset to s3 bucket"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!mkdir dataset\n",
+    "!wget -P dataset https://archive.ics.uci.edu/ml/machine-learning-databases/00280/HIGGS.csv.gz\n",
+    "!gunzip dataset/HIGGS.csv.gz"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s3_data_dir = session.upload_data(path=\"dataset\", key_prefix=\"dataset/higgs-dataset\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s3_data_dir"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Download latest RAPIDS container with cloud-ml examples\n",
+    "\n",
+    "Extend the container by copying the training script and installing [SageMaker Training toolkit](https://github.com/aws/sagemaker-training-toolkit) to makes RAPIDS compatible with SageMaker"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# estimator_info = {\n",
+    "#     'rapids_container': 'rapidsai/rapidsai-cloud-ml:latest',\n",
+    "#     'ecr_image': 'sagemaker-rapids-cloud-ml:latest',\n",
+    "#     'ecr_repository': 'sagemaker-rapids-cloud-ml'\n",
+    "# }"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "estimator_info = {\n",
+    "    \"rapids_container\": \"rapidsai/rapidsai-nightly:22.12-cuda11.5-runtime-ubuntu18.04-py3.9\",\n",
+    "    \"ecr_image\": \"sagemaker-rapids-nightly\",\n",
+    "    \"ecr_repository\": \"sagemaker-rapids-nightly\",\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "!docker pull {estimator_info['rapids_container']}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!cat docker/Dockerfile"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# FROM rapidsai/rapidsai-cloud-ml:latest\n",
+    "#!docker build -t sagemaker-rapids:latest docker"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!docker build -t sagemaker-rapids-nightly docker"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!docker images"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Publish to Elastic Container Registry"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note: SageMaker does not support using training images from private docker registry (ie. DockerHub), so we need to push\n",
+    "the SageMaker-compatible \\\n",
+    "RAPIDS container to the Amazon Elastic Container Registry."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ECR_container_fullname = (\n",
+    "    f\"{account}.dkr.ecr.{region}.amazonaws.com/{estimator_info['ecr_image']}\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ECR_container_fullname"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!docker tag {estimator_info['rapids_container']} {ECR_container_fullname}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\n",
+    "    f\"source      : {estimator_info['rapids_container']}\\n\"\n",
+    "    f\"destination : {ECR_container_fullname}\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!docker images"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!aws ecr create-repository --repository-name {estimator_info['ecr_repository']}\n",
+    "!$(aws ecr get-login --no-include-email --region {region})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!docker push {ECR_container_fullname}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Define hyperparameters: start with best guess values\n",
+    "Find the full list of Random Forest hyperparameters here in the RAPIDS doc page:\n",
+    "<br>\n",
+    "https://docs.rapids.ai/api/cuml/stable/api.html#random-forest"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hyperparams = {\n",
+    "    \"n_estimators\": 15,\n",
+    "    \"max_depth\": 5,\n",
+    "    \"n_bins\": 8,\n",
+    "    \"split_criterion\": 0,  # GINI:0, ENTROPY:1\n",
+    "    \"bootstrap\": 0,  # true: sample with replacement, false: sample without replacement\n",
+    "    \"max_leaves\": -1,  # unlimited leaves\n",
+    "    \"max_features\": 0.2,\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sagemaker.estimator import Estimator\n",
+    "\n",
+    "rapids_estimator = Estimator(\n",
+    "    image_uri=ECR_container_fullname,\n",
+    "    role=execution_role,\n",
+    "    instance_count=1,\n",
+    "    instance_type=\"ml.g4dn.4xlarge\",\n",
+    "    hyperparameters=hyperparams,\n",
+    "    metric_definitions=[{\"Name\": \"test_acc\", \"Regex\": \"test_acc: ([0-9\\\\.]+)\"}],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "rapids_estimator.fit(inputs=s3_data_dir)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sagemaker.tuner import (\n",
+    "    IntegerParameter,\n",
+    "    CategoricalParameter,\n",
+    "    ContinuousParameter,\n",
+    "    HyperparameterTuner,\n",
+    ")\n",
+    "\n",
+    "hyperparameter_ranges = {\n",
+    "    \"n_estimators\": IntegerParameter(10, 200),\n",
+    "    \"max_depth\": IntegerParameter(1, 22),\n",
+    "    \"n_bins\": IntegerParameter(5, 24),\n",
+    "    \"split_criterion\": CategoricalParameter([0, 1]),\n",
+    "    \"bootstrap\": CategoricalParameter([True, False]),\n",
+    "    \"max_features\": ContinuousParameter(0.01, 0.5),\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sagemaker.estimator import Estimator\n",
+    "\n",
+    "rapids_estimator = Estimator(\n",
+    "    image_uri=image,\n",
+    "    role=execution_role,\n",
+    "    instance_count=1,\n",
+    "    instance_type=\"ml.p3.2xlarge\",\n",
+    "    hyperparameters=hyperparams,\n",
+    "    metric_definitions=[{\"Name\": \"test_acc\", \"Regex\": \"test_acc: ([0-9\\\\.]+)\"}],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tuner = HyperparameterTuner(\n",
+    "    rapids_estimator,\n",
+    "    objective_metric_name=\"test_acc\",\n",
+    "    hyperparameter_ranges=hyperparameter_ranges,\n",
+    "    strategy=\"Bayesian\",\n",
+    "    max_jobs=1,\n",
+    "    max_parallel_jobs=1,\n",
+    "    objective_type=\"Maximize\",\n",
+    "    metric_definitions=[{\"Name\": \"test_acc\", \"Regex\": \"test_acc: ([0-9\\\\.]+)\"}],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "job_name = \"rapidsHPO\" + time.strftime(\"%Y-%m-%d-%H-%M-%S-%j\", time.gmtime())\n",
+    "tuner.fit({\"dataset\": s3_data_dir}, job_name=job_name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Clean up"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "- Delete S3 buckets and files you don't need\n",
+    "- Kill training jobs that you don't want running\n",
+    "- Delete container images and the repository you just created"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aws ecr delete-repository --force --repository-name"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "deployment-docs-dev",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13 | packaged by conda-forge | (main, May 27 2022, 16:58:50) \n[GCC 10.3.0]"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "f8a5d5d9459d186eb4ada656f03b674a34a7efd585f7a94c29caa9bfea516aa8"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }

--- a/source/examples/rapids-sagemaker-higgs/rapids-higgs.py
+++ b/source/examples/rapids-sagemaker-higgs/rapids-higgs.py
@@ -9,7 +9,6 @@ from sklearn.metrics import accuracy_score
 
 
 def main(args):
-
     # SageMaker options
     data_dir = args.data_dir
 
@@ -39,7 +38,6 @@ def main(args):
 
 
 if __name__ == "__main__":
-
     parser = argparse.ArgumentParser()
 
     # Hyper-parameters

--- a/source/examples/xgboost-gpu-hpo-job-parallel-k8s/notebook.ipynb
+++ b/source/examples/xgboost-gpu-hpo-job-parallel-k8s/notebook.ipynb
@@ -265,14 +265,17 @@
    "source": [
     "from dask_kubernetes.operator import KubeCluster\n",
     "\n",
-    "cluster = KubeCluster(name=\"rapids-dask\",\n",
-    "                      image=rapids_image,\n",
-    "                      worker_command=\"dask-cuda-worker\",\n",
-    "                      n_workers=n_workers,\n",
-    "                      resources={\"limits\": {\"nvidia.com/gpu\": \"1\"}},\n",
-    "                      env={\"DISABLE_JUPYTER\": \"true\",\n",
-    "                           \"EXTRA_PIP_PACKAGES\":\n",
-    "                               \"git+https://github.com/optuna/optuna.git@bc6c05dc655aab7e7a02e91e7306609f2a4524ec\"})"
+    "cluster = KubeCluster(\n",
+    "    name=\"rapids-dask\",\n",
+    "    image=rapids_image,\n",
+    "    worker_command=\"dask-cuda-worker\",\n",
+    "    n_workers=n_workers,\n",
+    "    resources={\"limits\": {\"nvidia.com/gpu\": \"1\"}},\n",
+    "    env={\n",
+    "        \"DISABLE_JUPYTER\": \"true\",\n",
+    "        \"EXTRA_PIP_PACKAGES\": \"git+https://github.com/optuna/optuna.git@bc6c05dc655aab7e7a02e91e7306609f2a4524ec\",\n",
+    "    },\n",
+    ")"
    ]
   },
   {
@@ -472,7 +475,7 @@
     "            \"futures\": [\n",
     "                client.submit(study.optimize, objective, n_trials=1, pure=False)\n",
     "                for _ in range(*iter_range)\n",
-    "            ]\n",
+    "            ],\n",
     "        }\n",
     "    )\n",
     "for partition in futures:\n",
@@ -551,6 +554,7 @@
     "import xgboost as xgb\n",
     "from optuna.samplers import RandomSampler\n",
     "\n",
+    "\n",
     "def objective(trial):\n",
     "    X, y = load_breast_cancer(return_X_y=True)\n",
     "    params = {\n",
@@ -565,16 +569,18 @@
     "        \"colsample_bytree\": trial.suggest_float(\"colsample_bytree\", 0.2, 1.0),\n",
     "        \"max_depth\": trial.suggest_int(\"max_depth\", 2, 10, step=1),\n",
     "        # minimum child weight, larger the term more conservative the tree.\n",
-    "        \"min_child_weight\": trial.suggest_float(\"min_child_weight\", 1e-8, 100, log=True),\n",
+    "        \"min_child_weight\": trial.suggest_float(\n",
+    "            \"min_child_weight\", 1e-8, 100, log=True\n",
+    "        ),\n",
     "        \"learning_rate\": trial.suggest_float(\"learning_rate\", 1e-8, 1.0, log=True),\n",
     "        # defines how selective algorithm is.\n",
     "        \"gamma\": trial.suggest_float(\"gamma\", 1e-8, 1.0, log=True),\n",
     "        \"grow_policy\": \"depthwise\",\n",
-    "        \"eval_metric\": \"logloss\"\n",
+    "        \"eval_metric\": \"logloss\",\n",
     "    }\n",
     "    clf = xgb.XGBClassifier(**params)\n",
     "    fold = KFold(n_splits=5, shuffle=True, random_state=0)\n",
-    "    score = cross_val_score(clf, X, y, cv=fold, scoring='neg_log_loss')\n",
+    "    score = cross_val_score(clf, X, y, cv=fold, scoring=\"neg_log_loss\")\n",
     "    return score.mean()"
    ]
   },
@@ -625,9 +631,9 @@
     "# Optimize in parallel on your Dask cluster\n",
     "backend_storage = optuna.storages.InMemoryStorage()\n",
     "dask_storage = optuna.integration.DaskStorage(storage=backend_storage, client=client)\n",
-    "study = optuna.create_study(direction=\"maximize\",\n",
-    "                            sampler=RandomSampler(seed=0),\n",
-    "                            storage=dask_storage)\n",
+    "study = optuna.create_study(\n",
+    "    direction=\"maximize\", sampler=RandomSampler(seed=0), storage=dask_storage\n",
+    ")\n",
     "futures = []\n",
     "for i in range(0, n_trials, n_workers * 4):\n",
     "    iter_range = (i, min([i + n_workers * 4, n_trials]))\n",
@@ -637,7 +643,7 @@
     "            \"futures\": [\n",
     "                client.submit(study.optimize, objective, n_trials=1, pure=False)\n",
     "                for _ in range(*iter_range)\n",
-    "            ]\n",
+    "            ],\n",
     "        }\n",
     "    )\n",
     "for partition in futures:\n",
@@ -709,7 +715,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from optuna.visualization.matplotlib import plot_optimization_history, plot_param_importances"
+    "from optuna.visualization.matplotlib import (\n",
+    "    plot_optimization_history,\n",
+    "    plot_param_importances,\n",
+    ")"
    ]
   },
   {

--- a/source/platforms/kubeflow.md
+++ b/source/platforms/kubeflow.md
@@ -152,12 +152,14 @@ This can take a similar amount of time to starting up the notebook container as 
 ```python
 from dask_kubernetes.experimental import KubeCluster
 
-cluster = KubeCluster(name="rapids-dask",
-                      image="rapidsai/rapidsai-core:22.06-cuda11.4-runtime-ubuntu20.04-py3.9",
-                      worker_command="dask-cuda-worker",
-                      n_workers=2,
-                      resources={"limits": {"nvidia.com/gpu": "1"}},
-                      env={"DISABLE_JUPYTER": "true"})
+cluster = KubeCluster(
+    name="rapids-dask",
+    image="rapidsai/rapidsai-core:22.06-cuda11.4-runtime-ubuntu20.04-py3.9",
+    worker_command="dask-cuda-worker",
+    n_workers=2,
+    resources={"limits": {"nvidia.com/gpu": "1"}},
+    env={"DISABLE_JUPYTER": "true"},
+)
 ```
 
 ```{figure} /images/kubeflow-jupyter-dask-cluster-widget.png

--- a/source/tools/kubernetes/dask-kubernetes.md
+++ b/source/tools/kubernetes/dask-kubernetes.md
@@ -28,14 +28,15 @@ User may create dask-cuda cluster either via `KubeCluster` interface:
 
 ```python
 from dask_kubernetes import KubeCluster, make_pod_spec
+
 gpu_worker_spec = make_pod_spec(
-    image='nvcr.io/nvidia/rapidsai/rapidsai-core:22.08-cuda11.5-runtime-ubuntu20.04-py3.9',
-    env={"DISABLE_JUPYTER":"true"},
+    image="nvcr.io/nvidia/rapidsai/rapidsai-core:22.08-cuda11.5-runtime-ubuntu20.04-py3.9",
+    env={"DISABLE_JUPYTER": "true"},
     cpu_limit=2,
     cpu_request=2,
-    memory_limit='3G',
-    memory_request='3G',
-    gpu_limit=1
+    memory_limit="3G",
+    memory_request="3G",
+    gpu_limit=1,
 )
 cluster = KubeCluster(gpu_worker_spec)
 ```
@@ -49,7 +50,7 @@ Alternatively, user can specify pod specs with standard kubernetes pod specifica
 Load the spec via:
 
 ```python
-cluster = KubeCluster('gpu-worker-spec.yaml')
+cluster = KubeCluster("gpu-worker-spec.yaml")
 ```
 
 ```{note}
@@ -72,8 +73,7 @@ Create a small `dask_cudf` dataframe and compute the result on the cluster:
 ```python
 import cudf, dask_cudf
 
-ddf = dask_cudf.from_cudf(cudf.DataFrame(
-    {'a': list(range(20))}), npartitions=2)
+ddf = dask_cudf.from_cudf(cudf.DataFrame({"a": list(range(20))}), npartitions=2)
 ddf.sum().compute()
 # should print a: 190
 ```

--- a/source/tools/kubernetes/dask-operator.md
+++ b/source/tools/kubernetes/dask-operator.md
@@ -327,12 +327,14 @@ In additon to creating clusters via `kubectl` you can also do so from Python wit
 ```python
 from dask_kubernetes.experimental import KubeCluster
 
-cluster = KubeCluster(name="rapids-dask",
-                      image="rapidsai/rapidsai-core:22.06-cuda11.5-runtime-ubuntu20.04-py3.9",
-                      n_workers=3,
-                      resources={"limit": {"nvidia.com/gpu": "1"}},
-                      env={"DISABLE_JUPYTER": "true"},
-                      worker_command="dask-cuda-worker")
+cluster = KubeCluster(
+    name="rapids-dask",
+    image="rapidsai/rapidsai-core:22.06-cuda11.5-runtime-ubuntu20.04-py3.9",
+    n_workers=3,
+    resources={"limit": {"nvidia.com/gpu": "1"}},
+    env={"DISABLE_JUPYTER": "true"},
+    worker_command="dask-cuda-worker",
+)
 ```
 
 If we check with `kubectl` we can see the above Python generated the same `DaskCluster` resource as the `kubectl` example above.


### PR DESCRIPTION
When migrating notebooks across I've noticed that some of them have unusual code styles. As usual, when code style comes up I just like to run black on things and stop worrying about it.

This PR adds two `pre-commit` hooks, one with `black[jupyter]` which runs on all `.py` and `.ipynb` files and one called `blacken-docs` which runs on any ` ```python ... ``` ` code fence in a markdown file.