### PR TITLE
Fix typo in dask-operator instructions

### DIFF
--- a/source/tools/kubernetes/dask-operator.md
+++ b/source/tools/kubernetes/dask-operator.md
@@ -328,9 +328,9 @@ In additon to creating clusters via `kubectl` you can also do so from Python wit
 from dask_kubernetes.experimental import KubeCluster
 
 cluster = KubeCluster(name="rapids-dask",
-                      image="rapidsai/rapidsai-core:22.06-cuda11.5-runtime-ubuntu20.04-py3.9",
+                      image="rapidsai/rapidsai-core:22.12-cuda11.5-runtime-ubuntu20.04-py3.9",
                       n_workers=3,
-                      resources={"limit": {"nvidia.com/gpu": "1"}},
+                      resources={"limits": {"nvidia.com/gpu": "1"}},
                       env={"DISABLE_JUPYTER": "true"},
                       worker_command="dask-cuda-worker")
 ```


### PR DESCRIPTION
`limit` => `limits` 

With this typo the cluster still gets created, but without GPUs. This took far too long to debug, we should probably open an issue on `dask-kubernetes` to do some better validation on the input config.

I also took the opportunity to bump the RAPIDS image to `22.12` as that's what I'm using.