### PR TITLE
Style changes to related files and tags

### DIFF
--- a/extensions/rapids_notebook_files.py
+++ b/extensions/rapids_notebook_files.py
@@ -19,14 +19,19 @@ def find_notebook_related_files(app, pagename, templatename, context, doctree):
         rel_page_parent = pathlib.Path(pagename).parent
         path_to_page_parent = source_root / rel_page_parent
 
+        related_notebook_dirs = []
         related_notebook_files = []
         for page in path_to_page_parent.glob("*"):
             if "ipynb" not in page.name:
-                related_notebook_files.append(
-                    f"{base_url}{rel_page_parent}/{page.name}"
-                )
+                url = f"{base_url}{rel_page_parent}/{page.name}"
+                if (path_to_page_parent / page).is_dir():
+                    related_notebook_dirs.append((page.name + "/", url))
+                else:
+                    related_notebook_files.append((page.name, url))
 
-        context["related_notebook_files"] = related_notebook_files
+        context["related_notebook_files"] = (
+            related_notebook_dirs + related_notebook_files
+        )
 
 
 def setup(app):

--- a/source/_static/css/custom.css
+++ b/source/_static/css/custom.css
@@ -14,6 +14,10 @@ nav.bd-links fieldset input {
   padding-right: 2em;
 }
 
+nav.related-files {
+  font-family: var(--pst-font-family-monospace);
+}
+
 nav.bd-links fieldset .sd-badge {
   font-size: 0.9em;
 }
@@ -71,4 +75,14 @@ nav.bd-links fieldset .sd-badge {
   color: #030200;
   background-color: #f09436;
   border-left: 0.5em #3194c7 solid;
+}
+
+.tag-dataset {
+  background-color: #cc539d;
+  border-left: 0.5em #cc539d solid;
+}
+
+.tag-workflow {
+  background-color: #348653;
+  border-left: 0.5em #348653 solid;
 }

--- a/source/_templates/notebooks-extra-files-nav.html
+++ b/source/_templates/notebooks-extra-files-nav.html
@@ -2,13 +2,11 @@
 <div class="tocsection onthispage">
   <i class="fa-regular fa-file"></i> Related files
 </div>
-<nav id="bd-toc-nav" class="page-toc">
+<nav id="bd-toc-nav" class="page-toc related-files">
   <ul class="visible nav section-nav flex-column">
-    {% for file in related_notebook_files %}
+    {% for name, url in related_notebook_files %}
     <li class="toc-h2 nav-item toc-entry">
-      <a class="reference external nav-link" href="{{ file }}">
-        {{ file.split("/")[-1] }}
-      </a>
+      <a class="reference external nav-link" href="{{ url }}"> {{ name }} </a>
     </li>
     {% endfor %}
   </ul>


### PR DESCRIPTION
Minor tweak to related files to ensure directories are sorted at the top and have a trailing slash to show they are a directory. Also changed to a monospace font.

<img width="283" alt="image" src="https://user-images.githubusercontent.com/1610850/217228818-0507692d-0fe6-48fb-a913-bec6b586769f.png">

Also added a couple of base tag styles for `workflow` and `dataset`.