### PR TITLE
Fix template rendering on pages with bad jinja2 characters

### DIFF
--- a/extensions/rapids_version_templating.py
+++ b/extensions/rapids_version_templating.py
@@ -1,23 +1,25 @@
+import re
+
+
 def version_template(app, docname, source):
     """Substitute versions into each page.
-
     This allows documentation pages and notebooks to substiture in values like
     the latest container image using jinja2 syntax.
-
     E.g
-
         # My doc page
-
         The latest container image is {{ rapids_container }}.
-
     """
 
     # Make sure we're outputting HTML
     if app.builder.format != "html":
         return
-    src = source[0]
-    rendered = app.builder.templates.render_string(src, app.config.rapids_version)
-    source[0] = rendered
+
+    def template_func(match):
+        return app.builder.templates.render_string(
+            match.group(), app.config.rapids_version
+        )
+
+    source[0] = re.sub(r"\{\{.*?\}\}", template_func, source[0])
 
 
 def setup(app):


### PR DESCRIPTION
Fixed the problem @betatim found in #141 where jinja2 didn't like certain characters. Fixed by using a regex to only apply templating to sections wrapped in `{{ }}`.