### PR TITLE
Add the databricks page to the platforms index

### DIFF
--- a/source/platforms/index.md
+++ b/source/platforms/index.md
@@ -39,4 +39,15 @@ Run RAPIDS on Coiled.
 {bdg}`multi-node`
 ````
 
+````{grid-item-card}
+:link: databricks
+:link-type: doc
+Databricks
+^^^
+Run RAPIDS on Databricks.
+
+{bdg}`single-node`
+{bdg}`multi-node`
+````
+
 `````


### PR DESCRIPTION
Looks like the databricks page wasn't in any TOC anywhere. Adding it to the platforms page.