### PR TITLE
Fix version templating

### DIFF
--- a/source/platforms/kubernetes.md
+++ b/source/platforms/kubernetes.md
@@ -37,7 +37,7 @@ spec:
     fsGroup: 0
   containers:
     - name: rapids-notebook
-      image: { { rapids_container } }
+      image: "{{ rapids_container }}"
       resources:
         limits:
           nvidia.com/gpu: 1


### PR DESCRIPTION
Fixes #155.

Instead of preprocessing the markdown/notebook files I've switched it up so we are postprocessing the doctree nodes and updating all of the text nodes. This is probably a more robust way to do this anyway. 

The included document fragments will have been fully resolved into nodes by the time we are postprcessing them so the templates will also get applied to them.

**Before**

![image](https://user-images.githubusercontent.com/1610850/220902517-ed8c0966-8527-4dbf-990f-de96ec116e78.png)

**After**

<img width="755" alt="image" src="https://user-images.githubusercontent.com/1610850/220902271-c62e3049-3be8-4de7-bbcb-d7905abcc570.png">

I also noticed the one in the Kubernetes page was broken because the linter has added spaces between the curly braces to make it valid YAML. Fixed by wrapping the template in quotes.