### PR TITLE
Exclude prompts from copybutton

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -67,6 +67,9 @@ templates_path = ["_templates"]
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = []
 
+copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "
+copybutton_prompt_is_regexp = True
+
 # -- Options for notebooks -------------------------------------------------
 
 nb_execution_mode = "off"


### PR DESCRIPTION
When `copybutton_prompt_text` is set, [sphinx-copybutton will remove the prompt](https://sphinx-copybutton.readthedocs.io/en/latest/use.html#strip-and-configure-input-prompts-for-code-cells) from the beginning of any lines that start with the text you specify. 

I used the regex example from their docs which removes `$`, `>>>` and Ipython things like `In [7]: ` and `Out [7]: `.

Closes #156 