### PR TITLE
[REVIEW] Fix docs build to be `pydata-sphinx-theme=0.13.0` compatible

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -81,6 +81,8 @@ rapids_deployment_notebooks_base_url = (
 
 html_theme_options = {
     "header_links_before_dropdown": 7,
+    # https://github.com/pydata/pydata-sphinx-theme/issues/1220
+    "icon_links": [],
     "logo": {
         "link": "https://docs.rapids.ai/",
     },


### PR DESCRIPTION
This PR fixes deployment docs build to be compatible with `pydata-sphinx-theme=0.13.0` by adding an empty `icon_links` entry.