### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*  @jacobtomlinson


### PR DESCRIPTION
I'm trying to clean up my GitHub notifications firehose at the moment and am finding using `CODEOWNERS` files helpful for automatically pinging me for a review. 