### PR TITLE
Change dataset tags to data-storage and data-format

### DIFF
--- a/source/_static/css/custom.css
+++ b/source/_static/css/custom.css
@@ -105,9 +105,14 @@ div.docref > .admonition-title::after {
   border-left: 0.5em #3194c7 solid;
 }
 
-.tag-dataset {
+.tag-data-format {
   background-color: #cc539d;
   border-left: 0.5em #cc539d solid;
+}
+
+.tag-data-storage {
+  background-color: #53a8cc;
+  border-left: 0.5em #53a8cc solid;
 }
 
 .tag-workflow {

--- a/source/_templates/notebooks-tag-filter.html
+++ b/source/_templates/notebooks-tag-filter.html
@@ -6,7 +6,9 @@
 
   {% for section in sorted(notebook_tag_tree) %}
   <fieldset aria-level="2" class="caption" role="heading">
-    <legend class="caption-text">{{ section.title() }}</legend>
+    <legend class="caption-text">
+      {{ section.title().replace("-", " ") }}
+    </legend>
     {% for tag in sorted(notebook_tag_tree[section]) %}
     <div>
       <input

--- a/source/examples/rapids-autoscaling-multi-tenant-kubernetes/notebook.ipynb
+++ b/source/examples/rapids-autoscaling-multi-tenant-kubernetes/notebook.ipynb
@@ -8,10 +8,11 @@
      "platform/kubernetes",
      "cloud/gcp/gke",
      "tools/dask-operator",
-     "dataset/nyc-taxi",
      "library/cuspatial",
      "library/dask",
-     "library/cudf"
+     "library/cudf",
+     "data-format/parquet",
+     "data-storage/gcs"
     ]
    },
    "source": [

--- a/source/examples/rapids-ec2-mnmg/notebook.ipynb
+++ b/source/examples/rapids-ec2-mnmg/notebook.ipynb
@@ -11,9 +11,10 @@
      "library/numpy",
      "library/dask-ml",
      "library/cudf",
-     "dataset/nyc-taxi",
      "workflow/randomforest",
-     "tools/dask-cloudprovider"
+     "tools/dask-cloudprovider",
+     "data-format/csv",
+     "data-storage/gcs"
     ]
    },
    "source": [
@@ -476,7 +477,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.9.15"
   },
   "vscode": {
    "interpreter": {

--- a/source/examples/rapids-sagemaker-higgs/notebook.ipynb
+++ b/source/examples/rapids-sagemaker-higgs/notebook.ipynb
@@ -9,7 +9,8 @@
      "library/cudf",
      "library/cuml",
      "library/scikit-learn",
-     "dataset/higgs-boson"
+     "data-format/csv",
+     "data-storage/s3"
     ]
    },
    "source": [

--- a/source/examples/rapids-sagemaker-hpo/notebook.ipynb
+++ b/source/examples/rapids-sagemaker-hpo/notebook.ipynb
@@ -11,8 +11,9 @@
      "library/cuml",
      "library/cupy",
      "library/cudf",
-     "dataset/airline",
-     "library/dask"
+     "library/dask",
+     "data-storage/s3",
+     "data-format/parquet"
     ]
    },
    "source": [


### PR DESCRIPTION
Closes #188 

Replaced the `dataset` tags with `data-storage` and `data-format` which will be more useful to users.

I also tweaked the template so that hyphenated tags get shown as two words `data-storage` => `Data Storage`.

<img width="1363" alt="image" src="https://user-images.githubusercontent.com/1610850/226899556-2aa47da9-2c08-4660-987b-31dbd00736c9.png">
