### PR TITLE
Update regex to exclude invalid templates

### DIFF
--- a/extensions/rapids_version_templating.py
+++ b/extensions/rapids_version_templating.py
@@ -9,7 +9,9 @@ class TextNodeVisitor(nodes.SparseNodeVisitor):
         super().__init__(*args, **kwargs)
 
     def visit_Text(self, node):
-        new_node = nodes.Text(re.sub(r"\{\{.*?\}\}", self.template_func, node.astext()))
+        new_node = nodes.Text(
+            re.sub(r"(?<!\$)\{\{.*?\}\}", self.template_func, node.astext())
+        )
         node.parent.replace(node, new_node)
 
     def template_func(self, match):


### PR DESCRIPTION
In #181 the version templating is incorrectly matching the Azure ML template string `${{inputs.data_dir}}`.

Added a negative lookbehind to ignore the `${{}}` style templating.