### PR TITLE
Update workflow permissions for AWS credentials

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -12,6 +12,10 @@ defaults:
   run:
     shell: bash -l {0}
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   conda:
     name: Build (and deploy)


### PR DESCRIPTION
After adding the `aws-actions/configure-aws-credentials` step in #214, this workflow also needs some updated permissions as described in https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services#adding-permissions-settings.

This should fix these errors that have been popping up since that PR was merged:

- https://github.com/rapidsai/deployment/actions/runs/4698469515/jobs/8330783891#step:6:17