### PR TITLE
Add Coiled Ubuntu 22.04 warning

### DIFF
--- a/source/platforms/coiled.md
+++ b/source/platforms/coiled.md
@@ -25,12 +25,16 @@ Next you'll need to register a RAPIDS software environment with Coiled.
 
 You can either build this from the official RAPIDS Container images.
 
+```{warning}
+Currently Coiled does not support Ubuntu 22.04 based images so be sure to select the 20.04 based image.
+```
+
 ```python
 import coiled
 
 coiled.create_software_environment(
     name="rapids-{{ rapids_version.replace(".", "-") }}",
-    container="{{ rapids_container }}",
+    container="{{ rapids_container.replace("ubuntu22.04", "ubuntu20.04") }}",
 )
 ```
 


### PR DESCRIPTION
Coiled does not currently support Ubuntu 22.04 based images which are now our default.

Updating our docs to ensure they still use Ubuntu 20.04 for Coiled and add a warning about Ubuntu 22.04.

xref https://github.com/coiled/feedback/issues/239