### PR TITLE
Add note about docker permissions/group

### DIFF
--- a/source/_includes/install-rapids-with-docker.md
+++ b/source/_includes/install-rapids-with-docker.md
@@ -12,3 +12,8 @@ docker run --gpus all --rm -it \
     -p 8888:8888 -p 8787:8787 -p 8786:8786 \
     {{ rapids_container }}
 ```
+
+```{note}
+If you see a "docker socket permission denied" error while running these commands try closing and reconnecting your
+SSH window. This happens because your user was added to the `docker` group only after you signed in.
+```


### PR DESCRIPTION
When testing https://docs.rapids.ai/deployment/nightly/cloud/gcp/compute-engine/ I had to reconnect my SSH because `groups` didn't list me as being a member of the `docker` group, but `/etc/group` did. I suspect this is because I got added to the group after connecting?

I added this note to let people know that all they need to do is reconnect, not go off and `groupadd` people etc. However I am unsure if it makes sense to have this comment everywhere where the docker commands are included? WDYT?