### PR TITLE
Update Vertex AI instructions

### DIFF
--- a/source/cloud/gcp/vertex-ai.md
+++ b/source/cloud/gcp/vertex-ai.md
@@ -24,11 +24,12 @@ $ docker push gcr.io/<project>/<folder>/{{ rapids_container.replace('rapidsai/',
 
 ## Create a New Notebook
 
-1. From the Google Cloud UI, navigate to [**Vertex AI**](https://console.cloud.google.com/vertex-ai) -> **Dashboard** and select **+ CREATE NOTEBOOK INSTANCE**.
-2. Under the **Environment** section, specify **Custom container**, and in the section below, select the `gcr.io` path to your pushed RAPIDS Docker image.
-3. Under **Machine Configuration** select an NVIDIA GPU.
-4. Check the **Install NVIDIA GPU Driver** option.
-5. After customizing any other aspects of the machine you wish, click **CREATE**.
+1. From the Google Cloud UI, navigate to [**Vertex AI**](https://console.cloud.google.com/vertex-ai) -> **Workbench** and select the **Managed Notebooks** tab. You do not want the similarly named "User-managed notebooks" tab.
+2. Select **NEW NOTEBOOK**.
+3. Under **Advanced settings**, in the **Environment** section, specify **Custom container**, and in the section below, select the `gcr.io` path to your pushed RAPIDS Docker image.
+4. Under **Machine Configuration** select an NVIDIA GPU.
+5. Check the **Install NVIDIA GPU Driver** option.
+6. After customizing any other aspects of the machine you wish, click **CREATE**.
 
 ## TEST RAPIDS
 


### PR DESCRIPTION
The labels in the UI changed a bit. Otherwise this works.

However, when I start the JupyterLab instance it "never" finishes loading the kernels from the custom image. I waited for 5 or so minutes before giving up :-/ We can add a note about "be patient", because it is confusing that the obvious "start a notebook" button doesn't have `cudf` in it. But I think if you have to wait minutes then that makes it a useless thing to have. Could there be something wrong with the image I built? Or some other explanation for why loading the extra kernels doesn't seem to happen?

<img width="532" alt="Screenshot 2023-06-08 at 10 40 49" src="https://github.com/rapidsai/deployment/assets/1448859/cde45464-153f-4ca4-bdb9-0c340883a1fa">
