### PR TITLE
Update VertexAI instructions to match new UI

### DIFF
--- a/source/cloud/gcp/vertex-ai.md
+++ b/source/cloud/gcp/vertex-ai.md
@@ -31,9 +31,15 @@ $ docker push gcr.io/<project>/<folder>/{{ rapids_container.replace('rapidsai/',
 5. Check the **Install NVIDIA GPU Driver** option.
 6. After customizing any other aspects of the machine you wish, click **CREATE**.
 
-## TEST RAPIDS
+## Test RAPIDS
 
-Once the managed notebook is fully configured, you can click **OPEN JUPYTERLAB** to navigate to another tab running JupyterLab to use the latest version of RAPIDS with Vertex AI.
+Once the managed notebook is fully configured, you can click **OPEN JUPYTERLAB** to navigate to another tab running JupyterLab.
+
+```warning
+You should see a popup letting you know it is loading the RAPIDS kernel, this can take a long time so please be patient.
+```
+
+Once the kernel is loaded you can launch a notebook with the `rapids` kernel to use the latest version of RAPIDS with Vertex AI.
 
 For example we could import and use RAPIDS libraries like `cudf`.
 

--- a/source/cloud/gcp/vertex-ai.md
+++ b/source/cloud/gcp/vertex-ai.md
@@ -25,9 +25,9 @@ $ docker push gcr.io/<project>/<folder>/{{ rapids_container.replace('rapidsai/',
 ## Create a New Notebook
 
 1. From the Google Cloud UI, navigate to [**Vertex AI**](https://console.cloud.google.com/vertex-ai) -> **Dashboard** and select **+ CREATE NOTEBOOK INSTANCE**.
-2. In the **Workbench type** section select **Managed Notebook** from the drop down menu.
-3. Under the **Environment** section, specify **Custom container**, and in the section below, select the `gcr.io` path to your pushed RAPIDS Docker image.
-4. Under **Machine Configuration** select an NVIDIA GPU.
+2. In the **Details** section, under the **Workbench type** heading select **Managed Notebook** from the drop down menu.
+3. Under the **Environment** section, select **Provide custom docker images**, and in the input field below, select the `gcr.io` path to your pushed RAPIDS Docker image.
+4. Under the **Machine type** section select an NVIDIA GPU.
 5. Check the **Install NVIDIA GPU Driver** option.
 6. After customizing any other aspects of the machine you wish, click **CREATE**.
 

--- a/source/cloud/gcp/vertex-ai.md
+++ b/source/cloud/gcp/vertex-ai.md
@@ -35,7 +35,7 @@ $ docker push gcr.io/<project>/<folder>/{{ rapids_container.replace('rapidsai/',
 
 Once the managed notebook is fully configured, you can click **OPEN JUPYTERLAB** to navigate to another tab running JupyterLab.
 
-```warning
+```{warning}
 You should see a popup letting you know it is loading the RAPIDS kernel, this can take a long time so please be patient.
 ```
 

--- a/source/cloud/gcp/vertex-ai.md
+++ b/source/cloud/gcp/vertex-ai.md
@@ -25,10 +25,11 @@ $ docker push gcr.io/<project>/<folder>/{{ rapids_container.replace('rapidsai/',
 ## Create a New Notebook
 
 1. From the Google Cloud UI, navigate to [**Vertex AI**](https://console.cloud.google.com/vertex-ai) -> **Dashboard** and select **+ CREATE NOTEBOOK INSTANCE**.
-2. Under the **Environment** section, specify **Custom container**, and in the section below, select the `gcr.io` path to your pushed RAPIDS Docker image.
-3. Under **Machine Configuration** select an NVIDIA GPU.
-4. Check the **Install NVIDIA GPU Driver** option.
-5. After customizing any other aspects of the machine you wish, click **CREATE**.
+2. In the **Workbench type** section select **Managed Notebook** from the drop down menu.
+3. Under the **Environment** section, specify **Custom container**, and in the section below, select the `gcr.io` path to your pushed RAPIDS Docker image.
+4. Under **Machine Configuration** select an NVIDIA GPU.
+5. Check the **Install NVIDIA GPU Driver** option.
+6. After customizing any other aspects of the machine you wish, click **CREATE**.
 
 ## TEST RAPIDS
 


### PR DESCRIPTION
Closes #265 

This updates the instructions for Vertex AI to match the new UI. The downside of this is that when you start the notebook loading the additional kernel takes "the age of the universe". I stopped waiting after maybe 10min or so.

This means this is kind of a solution, but also not really.

It seems like this method of using your own docker image (or using it in addition) is becoming deprecated. At least that is the feeling I get from how hidden the options are for selecting it.

---

I've tried installing rapids via conda or cudf via pip in a "bog standard" Vertex AI notebook environment. This kinda works. The conda install takes a long time to solve and then fails at the end with a permission error (`[Errno 13] Permission denied: '/opt/conda/lib/python3.10/site-packages/google/protobuf/__pycache__/__init__.cpython-310.pyc`). The `pip` route is much quicker, it also fails with a permission error.

`nvidia-smi` output:
```
Tue Aug  8 07:56:57 2023       
+-----------------------------------------------------------------------------+
| NVIDIA-SMI 510.47.03    Driver Version: 510.47.03    CUDA Version: 11.6     |
|-------------------------------+----------------------+----------------------+
| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
|                               |                      |               MIG M. |
|===============================+======================+======================|
|   0  Tesla P100-PCIE...  Off  | 00000000:00:04.0 Off |                    0 |
| N/A   43C    P0    29W / 250W |      0MiB / 16384MiB |      3%      Default |
|                               |                      |                  N/A |
+-------------------------------+----------------------+----------------------+
                                                                               
+-----------------------------------------------------------------------------+
| Processes:                                                                  |
|  GPU   GI   CI        PID   Type   Process name                  GPU Memory |
|        ID   ID                                                   Usage      |
|=============================================================================|
|  No running processes found                                                 |
+-----------------------------------------------------------------------------+
```