### PR TITLE
Conf.py 23.08 update

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -22,7 +22,7 @@ author = "NVIDIA"
 
 # Single modifiable version for all of the docs - easier for future updates
 stable_version = "23.08"
-nightly_version = "23.10a"
+nightly_version = "23.10"
 
 versions = {
     "stable": {
@@ -33,9 +33,9 @@ versions = {
     },
     "nightly": {
         "rapids_version": nightly_version,
-        "rapids_container": f"rapidsai/base:{nightly_version}-cuda11.8-py3.10",
+        "rapids_container": f"rapidsai/base:{nightly_version + 'a'}-cuda11.8-py3.10",
         "rapids_conda_channels": "-c rapidsai-nightly -c conda-forge -c nvidia",
-        "rapids_conda_packages": f"rapids={nightly_version[:-1]} python=3.10 cudatoolkit=11.8",
+        "rapids_conda_packages": f"rapids={nightly_version} python=3.10 cudatoolkit=11.8",
     },
 }
 rapids_version = (

--- a/source/conf.py
+++ b/source/conf.py
@@ -33,7 +33,7 @@ versions = {
     },
     "nightly": {
         "rapids_version": nightly_version,
-        "rapids_container": f"rapidsai/base:{nightly_version}-cuda11.8-runtime-ubuntu22.04-py3.10",
+        "rapids_container": f"rapidsai/base:{nightly_version}-cuda11.8-py3.10",
         "rapids_conda_channels": "-c rapidsai-nightly -c conda-forge -c nvidia",
         "rapids_conda_packages": f"rapids={nightly_version[:-1]} python=3.10 cudatoolkit=11.8",
     },

--- a/source/conf.py
+++ b/source/conf.py
@@ -32,7 +32,7 @@ versions = {
         "rapids_conda_packages": f"rapids={stable_version} python=3.10 cudatoolkit=11.8",
     },
     "nightly": {
-        "rapids_version": nightly_version,
+        "rapids_version": f"{nightly_version}-nightly",
         "rapids_container": f"rapidsai/base:{nightly_version + 'a'}-cuda11.8-py3.10",
         "rapids_conda_channels": "-c rapidsai-nightly -c conda-forge -c nvidia",
         "rapids_conda_packages": f"rapids={nightly_version} python=3.10 cudatoolkit=11.8",

--- a/source/conf.py
+++ b/source/conf.py
@@ -20,18 +20,22 @@ project = "RAPIDS Deployment Documentation"
 copyright = f"{datetime.date.today().year}, NVIDIA"
 author = "NVIDIA"
 
+# Single modifiable version for all of the docs - easier for future updates
+stable_version = "23.08"
+nightly_version = "23.10a"
+
 versions = {
     "stable": {
-        "rapids_version": "23.06",
-        "rapids_container": "nvcr.io/nvidia/rapidsai/rapidsai-core:23.06-cuda11.8-runtime-ubuntu22.04-py3.10",
+        "rapids_version": stable_version,
+        "rapids_container": f"nvcr.io/nvidia/rapidsai/base:{stable_version}-cuda11.8-py3.10",
         "rapids_conda_channels": "-c rapidsai -c conda-forge -c nvidia",
-        "rapids_conda_packages": "rapids=23.06 python=3.10 cudatoolkit=11.8",
+        "rapids_conda_packages": f"rapids={stable_version} python=3.10 cudatoolkit=11.8",
     },
     "nightly": {
-        "rapids_version": "23.08-nightly",
-        "rapids_container": "rapidsai/rapidsai-core-nightly:23.08-cuda11.8-runtime-ubuntu22.04-py3.10",
+        "rapids_version": nightly_version,
+        "rapids_container": f"rapidsai/base:{nightly_version}-cuda11.8-runtime-ubuntu22.04-py3.10",
         "rapids_conda_channels": "-c rapidsai-nightly -c conda-forge -c nvidia",
-        "rapids_conda_packages": "rapids=23.08 python=3.10 cudatoolkit=11.8",
+        "rapids_conda_packages": f"rapids={nightly_version[:-1]} python=3.10 cudatoolkit=11.8",
     },
 }
 rapids_version = (


### PR DESCRIPTION
This PR does two things to `conf.py`

1. Updates the Docker pull commands to match the[ RAPIDS 23.08 updates](https://github.com/rapidsai/docker/issues/539)
2. Updates the script so we only need to update the versions in 1 place to reduce human error possibility

It also updates the versions for `23.08` since we'll need to do that prior to release anyway.