### PR TITLE
Update TCO benchmark to run training jobs in parallel

### DIFF
--- a/source/examples/xgboost-rf-gpu-cpu-benchmark/Dockerfile
+++ b/source/examples/xgboost-rf-gpu-cpu-benchmark/Dockerfile
@@ -1,5 +1,3 @@
-#FROM rapidsai/rapidsai:23.06-cuda11.5-runtime-ubuntu20.04-py3.10
+FROM rapidsai/base:23.10a-cuda12.0-py3.10
 
-FROM rapidsai/rapidsai:23.06-cuda11.8-runtime-ubuntu22.04-py3.10
-
-RUN mamba install -y -n rapids optuna
+RUN mamba install -y -n base optuna

--- a/source/examples/xgboost-rf-gpu-cpu-benchmark/hpo.py
+++ b/source/examples/xgboost-rf-gpu-cpu-benchmark/hpo.py
@@ -151,7 +151,7 @@ def main(args):
             threads_per_worker=args.threads_per_worker,
         )
     n_workers = len(cluster.workers)
-    n_trials = 8
+    n_trials = 100
 
     dataset = None
     # For CPU target, load the data matrix once and shared it among workers

--- a/source/examples/xgboost-rf-gpu-cpu-benchmark/hpo.py
+++ b/source/examples/xgboost-rf-gpu-cpu-benchmark/hpo.py
@@ -4,13 +4,11 @@ import os
 import time
 from functools import partial
 
-import dask
 import optuna
 import pandas as pd
 import xgboost as xgb
 from dask.distributed import Client, LocalCluster, wait
 from dask_cuda import LocalCUDACluster
-from optuna.samplers import RandomSampler
 from sklearn.ensemble import RandomForestClassifier as RF_cpu
 from sklearn.metrics import accuracy_score as accuracy_score_cpu
 from sklearn.model_selection import train_test_split
@@ -119,7 +117,7 @@ def train_randomforest(trial, *, target, dataset=None, threads_per_worker=None):
     }
 
     cv_fold_scores = []
-    for i_fold in range(n_cv_folds):
+    for _i_fold in range(n_cv_folds):
         X_train, y_train, X_test, y_test = preprocess_data(dataset)
 
         if target == "gpu":

--- a/source/examples/xgboost-rf-gpu-cpu-benchmark/hpo.py
+++ b/source/examples/xgboost-rf-gpu-cpu-benchmark/hpo.py
@@ -2,16 +2,18 @@ import argparse
 import glob
 import os
 import time
+from functools import partial
 
 import dask
 import optuna
+import pandas as pd
 import xgboost as xgb
 from dask.distributed import Client, LocalCluster, wait
 from dask_cuda import LocalCUDACluster
-from dask_ml.model_selection import train_test_split
 from optuna.samplers import RandomSampler
 from sklearn.ensemble import RandomForestClassifier as RF_cpu
 from sklearn.metrics import accuracy_score as accuracy_score_cpu
+from sklearn.model_selection import train_test_split
 
 n_cv_folds = 5
 
@@ -34,23 +36,23 @@ feature_columns = [
 ]
 
 
-def ingest_data(mode):
-    if mode == "gpu":
-        import dask_cudf
+def ingest_data(target):
+    if target == "gpu":
+        import cudf
 
-        dataset = dask_cudf.read_parquet(
+        dataset = cudf.read_parquet(
             glob.glob("./data/*.parquet"),
             columns=feature_columns,
         )
     else:
-        dataset = dask.dataframe.read_parquet(
+        dataset = pd.read_parquet(
             glob.glob("./data/*.parquet"),
             columns=feature_columns,
-        ).repartition(npartitions=1000)
+        )
     return dataset
 
 
-def preprocess_data(dataset, *, client, i_fold, mode):
+def preprocess_data(dataset, *, i_fold):
     dataset = dataset.dropna()
     train, test = train_test_split(dataset, random_state=i_fold, shuffle=True)
     X_train, y_train = train.drop(label_column, axis=1), train[label_column]
@@ -58,22 +60,13 @@ def preprocess_data(dataset, *, client, i_fold, mode):
     X_train, y_train = X_train.astype("float32"), y_train.astype("int32")
     X_test, y_test = X_test.astype("float32"), y_test.astype("int32")
 
-    if mode == "gpu":
-        from cuml.dask.common.utils import persist_across_workers
-
-        X_train, y_train, X_test, y_test = persist_across_workers(
-            client, [X_train, y_train, X_test, y_test], workers=client.has_what().keys()
-        )
-    else:
-        X_train, y_train = X_train.persist(), y_train.persist()
-        X_test, y_test = X_test.persist(), y_test.persist()
-
-    wait([X_train, y_train, X_test, y_test])
-
     return X_train, y_train, X_test, y_test
 
 
-def train_xgboost(trial, *, dataset, client, mode):
+def train_xgboost(trial, *, target, dataset=None, threads_per_worker=None):
+    if target == "gpu":
+        dataset = ingest_data(target)
+
     params = {
         "max_depth": trial.suggest_int("max_depth", 4, 8),
         "learning_rate": trial.suggest_float("learning_rate", 0.001, 0.1, log=True),
@@ -89,38 +82,34 @@ def train_xgboost(trial, *, dataset, client, mode):
 
     cv_fold_scores = []
     for i_fold in range(n_cv_folds):
-        X_train, y_train, X_test, y_test = preprocess_data(
-            dataset, client=client, i_fold=i_fold, mode=mode
-        )
+        X_train, y_train, X_test, y_test = preprocess_data(dataset, i_fold=i_fold)
+        dtrain = xgb.QuantileDMatrix(X_train, label=y_train)
+        dtest = xgb.QuantileDMatrix(X_test)
 
-        if mode == "gpu":
+        if target == "gpu":
             from cuml.metrics import accuracy_score as accuracy_score_gpu
 
             params["tree_method"] = "gpu_hist"
-            dtrain = xgb.dask.DaskDeviceQuantileDMatrix(client, X_train, y_train)
-            dtest = xgb.dask.DaskDeviceQuantileDMatrix(client, X_test)
             accuracy_score_func = accuracy_score_gpu
         else:
             params["tree_method"] = "hist"
-            dtrain = xgb.dask.DaskDMatrix(client, X_train, y_train)
-            dtest = xgb.dask.DaskDMatrix(client, X_test)
+            params["nthread"] = threads_per_worker
             accuracy_score_func = accuracy_score_cpu
 
-        xgboost_output = xgb.dask.train(
-            client, params, dtrain, num_boost_round=num_boost_round
-        )
-        trained_model = xgboost_output["booster"]
+        trained_model = xgb.train(params, dtrain, num_boost_round=num_boost_round)
 
-        pred = xgb.dask.predict(client, trained_model, dtest) > 0.5
-        pred = pred.astype("int32").compute()
-        y_test = y_test.compute()
+        pred = trained_model.predict(dtest) > 0.5
+        pred = pred.astype("int32")
         score = accuracy_score_func(y_test, pred)
         cv_fold_scores.append(score)
     final_score = sum(cv_fold_scores) / len(cv_fold_scores)
     return final_score
 
 
-def train_randomforest(trial, *, dataset, client, mode):
+def train_randomforest(trial, *, target, dataset=None, threads_per_worker=None):
+    if target == "gpu":
+        dataset = ingest_data(target)
+
     params = {
         "max_depth": trial.suggest_int("max_depth", 5, 15),
         "max_features": trial.suggest_float("max_features", 0.1, 1.0),
@@ -131,27 +120,22 @@ def train_randomforest(trial, *, dataset, client, mode):
 
     cv_fold_scores = []
     for i_fold in range(n_cv_folds):
-        X_train, y_train, X_test, y_test = preprocess_data(
-            dataset, client=client, i_fold=i_fold, mode=mode
-        )
+        X_train, y_train, X_test, y_test = preprocess_data(dataset)
 
-        if mode == "gpu":
-            from cuml.dask.ensemble import RandomForestClassifier as RF_gpu
+        if target == "gpu":
+            from cuml.ensemble import RandomForestClassifier as RF_gpu
             from cuml.metrics import accuracy_score as accuracy_score_gpu
 
             params["n_bins"] = 256
-            trained_model = RF_gpu(client=client, **params)
+            trained_model = RF_gpu(**params)
             accuracy_score_func = accuracy_score_gpu
         else:
-            params["n_jobs"] = -1
+            params["n_jobs"] = threads_per_worker
             trained_model = RF_cpu(**params)
             accuracy_score_func = accuracy_score_cpu
 
         trained_model.fit(X_train, y_train)
         pred = trained_model.predict(X_test)
-        if mode == "gpu":
-            pred = pred.compute()
-        y_test = y_test.compute()
         score = accuracy_score_func(y_test, pred)
         cv_fold_scores.append(score)
     final_score = sum(cv_fold_scores) / len(cv_fold_scores)
@@ -161,37 +145,82 @@ def train_randomforest(trial, *, dataset, client, mode):
 def main(args):
     tstart = time.perf_counter()
 
-    study = optuna.create_study(
-        sampler=RandomSampler(seed=args.seed), direction="maximize"
-    )
-
-    if args.mode == "gpu":
+    if args.target == "gpu":
         cluster = LocalCUDACluster()
     else:
-        cluster = LocalCluster(n_workers=os.cpu_count())
+        cluster = LocalCluster(
+            n_workers=os.cpu_count() // args.threads_per_worker,
+            threads_per_worker=args.threads_per_worker,
+        )
+    n_workers = len(cluster.workers)
+    n_trials = 8
 
-    with Client(cluster) as client:
-        dataset = ingest_data(mode=args.mode)
-        client.persist(dataset)
-        if args.model_type == "XGBoost":
-            study.optimize(
-                lambda trial: train_xgboost(
-                    trial, dataset=dataset, client=client, mode=args.mode
-                ),
-                n_trials=100,
-                n_jobs=1,
-            )
+    dataset = None
+    # For CPU target, load the data matrix once and shared it among workers
+    # For GPU target, each worker process will get its own data matrix
+    if args.target == "cpu":
+        dataset = ingest_data("cpu")
+
+    futures = []
+    if args.model_type == "XGBoost":
+        if args.target == "gpu":
+            objective_func = partial(train_xgboost, target=args.target)
         else:
-            study.optimize(
-                lambda trial: train_randomforest(
-                    trial, dataset=dataset, client=client, mode=args.mode
-                ),
-                n_trials=100,
-                n_jobs=1,
+            objective_func = partial(
+                train_xgboost,
+                target=args.target,
+                dataset=dataset,
+                threads_per_worker=args.threads_per_worker,
             )
+    else:
+        if args.target == "gpu":
+            objective_func = partial(train_randomforest, target=args.target)
+        else:
+            objective_func = partial(
+                train_randomforest,
+                target=args.target,
+                dataset=dataset,
+                threads_per_worker=args.threads_per_worker,
+            )
+    with Client(cluster) as client:
+        backend_storage = optuna.storages.InMemoryStorage()
+        dask_storage = optuna.integration.DaskStorage(
+            storage=backend_storage, client=client
+        )
 
+        study = optuna.create_study(
+            direction="maximize",
+            sampler=optuna.samplers.RandomSampler(seed=args.seed),
+            storage=dask_storage,
+        )
+        for i in range(0, n_trials, n_workers):
+            iter_range = (i, min([i + n_workers, n_trials]))
+            futures.append(
+                {
+                    "range": iter_range,
+                    "futures": [
+                        client.submit(
+                            study.optimize, objective_func, n_trials=1, pure=False
+                        )
+                        for _ in range(*iter_range)
+                    ],
+                }
+            )
+        for partition in futures:
+            iter_range = partition["range"]
+            print(
+                f"Testing hyperparameter combinations {iter_range[0]}..{iter_range[1]}"
+            )
+            _ = wait(partition["futures"])
+            for fut in partition["futures"]:
+                _ = fut.result()  # Ensure that the training job was successful
+            tnow = time.perf_counter()
+            print(
+                f"Best cross-validation metric: {study.best_value}, Time elapsed = {tnow - tstart}"
+            )
     tend = time.perf_counter()
     print(f"Time elapsed: {tend - tstart} sec")
+    cluster.close()
 
 
 if __name__ == "__main__":
@@ -199,7 +228,14 @@ if __name__ == "__main__":
     parser.add_argument(
         "--model-type", type=str, required=True, choices=["XGBoost", "RandomForest"]
     )
-    parser.add_argument("--mode", required=True, choices=["gpu", "cpu"])
+    parser.add_argument("--target", required=True, choices=["gpu", "cpu"])
     parser.add_argument("--seed", required=False, type=int, default=1)
+    parser.add_argument(
+        "--threads_per_worker",
+        required=False,
+        type=int,
+        default=4,
+        help="Number of threads per worker process. Only applicable for CPU target",
+    )
     args = parser.parse_args()
     main(args)


### PR DESCRIPTION
When using VMs with multiple GPUs, it is more advantageous to run multiple training jobs in parallel, rather than running one training job at a time.