### PR TITLE
Updates for 23.12 release

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -21,8 +21,8 @@ copyright = f"{datetime.date.today().year}, NVIDIA"
 author = "NVIDIA"
 
 # Single modifiable version for all of the docs - easier for future updates
-stable_version = "23.10"
-nightly_version = "23.12"
+stable_version = "23.12"
+nightly_version = "23.10"
 
 versions = {
     "stable": {
@@ -30,14 +30,14 @@ versions = {
         "rapids_container": f"nvcr.io/nvidia/rapidsai/base:{stable_version}-cuda11.8-py3.10",
         "rapids_notebooks_container": f"nvcr.io/nvidia/rapidsai/notebooks:{stable_version}-cuda11.8-py3.10",
         "rapids_conda_channels": "-c rapidsai -c conda-forge -c nvidia",
-        "rapids_conda_packages": f"rapids={stable_version} python=3.10 cudatoolkit=11.8",
+        "rapids_conda_packages": f"rapids={stable_version} python=3.10 cuda-version=11.8",
     },
     "nightly": {
         "rapids_version": f"{nightly_version}-nightly",
         "rapids_container": f"rapidsai/base:{nightly_version + 'a'}-cuda11.8-py3.10",
         "rapids_notebooks_container": f"rapidsai/notebooks:{nightly_version + 'a'}-cuda11.8-py3.10",
         "rapids_conda_channels": "-c rapidsai-nightly -c conda-forge -c nvidia",
-        "rapids_conda_packages": f"rapids={nightly_version} python=3.10 cudatoolkit=11.8",
+        "rapids_conda_packages": f"rapids={nightly_version} python=3.10 cuda-version=11.8",
     },
 }
 rapids_version = (

--- a/source/conf.py
+++ b/source/conf.py
@@ -22,7 +22,7 @@ author = "NVIDIA"
 
 # Single modifiable version for all of the docs - easier for future updates
 stable_version = "23.12"
-nightly_version = "23.10"
+nightly_version = "24.02"
 
 versions = {
     "stable": {


### PR DESCRIPTION
Bump the version for the `23.12` release.

Also, switch `cudatoolkit` to `cuda-version` which is the preferred package for selecting the CUDA version since it is compatible with both CUDA 11 & 12.
