### PR TITLE
Update validation Pod to latest

### DIFF
--- a/source/_includes/check-gpu-pod-works.md
+++ b/source/_includes/check-gpu-pod-works.md
@@ -10,7 +10,7 @@ spec:
   restartPolicy: OnFailure
   containers:
   - name: cuda-vectoradd
-    image: "nvidia/samples:vectoradd-cuda11.2.1"
+    image: "nvidia/samples:vectoradd-cuda11.6.0-ubuntu18.04"
     resources:
        limits:
          nvidia.com/gpu: 1


### PR DESCRIPTION
It looks like the vectoradd containers haven't been updated for a while. We currently mention CUDA 11.2 but there is a more recent (but still not very recent) CUDA 11.6. Bumping it up anyway.