### PR TITLE
fix cuspatial.haversine_distance() example in multi-tenant notebook

### DIFF
--- a/source/examples/rapids-autoscaling-multi-tenant-kubernetes/notebook.ipynb
+++ b/source/examples/rapids-autoscaling-multi-tenant-kubernetes/notebook.ipynb
@@ -1127,7 +1127,7 @@
     "            client.wait_for_workers(2)\n",
     "            df = dd.read_parquet(\n",
     "                \"gcs://anaconda-public-data/nyc-taxi/2015.parquet\",\n",
-    "                storage_options={\"token\": \"cloud\"},\n",
+    "                storage_options={\"token\": \"anon\"},\n",
     "            )\n",
     "            client.compute(df.map_partitions(map_haversine))"
    ]

--- a/source/examples/rapids-autoscaling-multi-tenant-kubernetes/notebook.ipynb
+++ b/source/examples/rapids-autoscaling-multi-tenant-kubernetes/notebook.ipynb
@@ -971,8 +971,8 @@
     "dask.config.set({\"dataframe.backend\": \"cudf\"})\n",
     "\n",
     "df = dd.read_parquet(\n",
-    "    \"gcs://anaconda-public-data/nyc-taxi/2015.parquet\",\n",
-    "    storage_options={\"token\": \"cloud\"},\n",
+    "    \"gcs://anaconda-public-data/nyc-taxi/2015.parquet/part.1*\",\n",
+    "    storage_options={\"token\": \"anon\"},\n",
     ").persist()\n",
     "wait(df)\n",
     "df"
@@ -991,16 +991,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from cuspatial import haversine_distance\n",
+    "import cuspatial\n",
     "\n",
     "\n",
     "def map_haversine(part):\n",
-    "    return haversine_distance(\n",
-    "        part[\"pickup_longitude\"],\n",
-    "        part[\"pickup_latitude\"],\n",
-    "        part[\"dropoff_longitude\"],\n",
-    "        part[\"dropoff_latitude\"],\n",
+    "    pickup = cuspatial.GeoSeries.from_points_xy(\n",
+    "        part[[\"pickup_longitude\", \"pickup_latitude\"]].interleave_columns()\n",
     "    )\n",
+    "    dropoff = cuspatial.GeoSeries.from_points_xy(\n",
+    "        part[[\"dropoff_longitude\", \"dropoff_latitude\"]].interleave_columns()\n",
+    "    )\n",
+    "    return cuspatial.haversine_distance(pickup, dropoff)\n",
     "\n",
     "\n",
     "df[\"haversine_distance\"] = df.map_partitions(map_haversine)"
@@ -2232,7 +2233,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.15"
+   "version": "3.9.18"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
Fixes the `cuspatial.haversine_distance()` example using the public NYC taxi data hosted on GSC ([GSC console link](https://console.cloud.google.com/storage/browser/anaconda-public-data/nyc-taxi/2015.parquet;tab=objects?prefix=&forceOnObjectsSortingFiltering=false)).

Running through the notebook code for that example (the same one that ends up at https://docs.rapids.ai/deployment/nightly/examples/rapids-autoscaling-multi-tenant-kubernetes/notebook/), I encountered 3 issues:

1. needed to authenticate with GCP

```text
ValueError: An error occurred while calling the read_parquet method registered to the cudf backend.
Original Message: An error occurred while calling the read_parquet method registered to the pandas backend.
Original Message: Invalid gcloud credentials
```

2. that GCS bucket contains some files at path `gcs://anaconda-public-data/nyc-taxi/2015.parquet` that are not actually parquet files

<img width="1097" alt="Screenshot 2024-02-05 at 1 20 07 PM" src="https://github.com/rapidsai/deployment/assets/7608904/2ca2e6fd-1711-4231-a9f4-d489b56de64d">

3. `cuspatial.haversine_distance()` expects to receive 2 `cuspatial.GeoSeries` objects

```text
TypeError('haversine_distance() takes 2 positional arguments but 4 were given')
```

Looks like that changed here: https://github.com/rapidsai/cuspatial/pull/924.

This resolves those issues.

### How I tested this

Following the instructions from https://docs.rapids.ai/install#install-rapids, ran jupyter lab in a RAPIDS container like this:

```shell
docker run \
    --gpus all \
    --pull always \
    --rm \
    -it \
    --shm-size=1g \
    --ulimit memlock=-1 \
    --ulimit stack=67108864 \
    -p 8888:8888 \
    -p 8787:8787 \
    -p 8786:8786 \
    rapidsai/notebooks:24.02a-cuda12.0-py3.10
```

Then ran this notebook code (just the `LocalCUDACluster` parts and below), on a machine with a few 80GB H100s. Confirmed that data was pulled successfully without needing to authenticate with GCP, and that `cuspatial.haversine_distance()` ran without error and produced plausible-looking results.
