### PR TITLE
Update ec2.md with note on failing to install drivers

### DIFF
--- a/source/cloud/aws/ec2.md
+++ b/source/cloud/aws/ec2.md
@@ -28,6 +28,10 @@ Next we need to connect to the instance.
 
 ```
 
+```{note}
+If you see a "modprobe: FATAL: Module nvidia not found in directory /lib/modules/6.2.0-1011-aws" while first connecting to the EC2 instance, try logging out and reconnecting again.
+```
+
 ## Test RAPIDS
 
 ```{include} ../../_includes/test-rapids-docker-vm.md


### PR DESCRIPTION
Just came across this error while connecting to an EC2 instance. The fix was suggested at https://forums.developer.nvidia.com/t/nvidia-gpu-optimized-ami-is-missing-drivers-and-cant-run-the-pytorch-ngc-dockerfile/276492/2 and made a note here in case others come across this.