### PR TITLE
Add link to nvidia.com

### DIFF
--- a/source/cloud/nvidia/index.md
+++ b/source/cloud/nvidia/index.md
@@ -4,6 +4,12 @@ html_theme.sidebar_secondary.remove: true
 
 # NVIDIA DGX Cloud
 
+```{note}
+NVIDIA DGX™ Cloud is an AI platform for enterprise developers, optimized for the demands of generative AI.
+
+[Learn more at nvidia.com](https://www.nvidia.com/en-gb/data-center/dgx-cloud/).
+```
+
 ```{include} ../../_includes/menus/nvidia.md
 
 ```


### PR DESCRIPTION
I think it makes sense to link to nvidia.com resources from the DGX Cloud page.