### PR TITLE
remove use of star imports in rapids-sagemaker-hpo notebook

### DIFF
--- a/source/examples/rapids-sagemaker-hpo/notebook.ipynb
+++ b/source/examples/rapids-sagemaker-hpo/notebook.ipynb
@@ -110,8 +110,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os\n",
+    "\n",
     "import sagemaker\n",
-    "from helper_functions import *"
+    "from helper_functions import (\n",
+    "    download_best_model,\n",
+    "    new_job_name_from_config,\n",
+    "    recommend_instance_type,\n",
+    "    summarize_choices,\n",
+    "    summarize_hpo_results,\n",
+    "    validate_dockerfile,\n",
+    ")"
    ]
   },
   {
@@ -1526,7 +1535,7 @@
     "    \"sagemaker_session\": session,\n",
     "}\n",
     "\n",
-    "if use_spot_instances_flag == True:\n",
+    "if use_spot_instances_flag:\n",
     "    estimator_params.update({\"max_wait\": max_duration_of_experiment_seconds + 1})"
    ]
   },


### PR DESCRIPTION
Contributes to #333.

Fixes these issues in `rapids-sagemaker-hpo/notebook.ipynb` found by `ruff`:

```text
F403 `from helper_functions import *` used; unable to detect undefined names
F405 `os` may be undefined, or defined from star imports
F405 `recommend_instance_type` may be undefined, or defined from star imports
F405 `summarize_choices` may be undefined, or defined from star imports
F405 `validate_dockerfile` may be undefined, or defined from star imports
E712 Avoid equality comparisons to `True`; use `if use_spot_instances_flag:` for truth checks
F405 `summarize_choices` may be undefined, or defined from star imports
F405 `new_job_name_from_config` may be undefined, or defined from star imports
F405 `summarize_choices` may be undefined, or defined from star imports
F405 `summarize_hpo_results` may be undefined, or defined from star imports
F405 `download_best_model` may be undefined, or defined from star import
```

I agree with `ruff` here... I think it'd be clearer to not have the star imports. And doing that also improves the likelihood of linters being able to catch issues in the way those functions being imported like `from helper_functions import *` are called.