### PR TITLE
WIP: install tomli in docs environment

### DIFF
--- a/conda/environments/deployment_docs.yml
+++ b/conda/environments/deployment_docs.yml
@@ -10,9 +10,8 @@ dependencies:
   - pydata-sphinx-theme>=0.12.0
   - python=3.9
   - pre-commit
-  - sphinx
+  - sphinx>=7.3.5
   - sphinx-autobuild
   - sphinx-copybutton
   - sphinx-design
   - sphinxcontrib-mermaid
-  - tomli

--- a/conda/environments/deployment_docs.yml
+++ b/conda/environments/deployment_docs.yml
@@ -15,3 +15,4 @@ dependencies:
   - sphinx-copybutton
   - sphinx-design
   - sphinxcontrib-mermaid
+  - tomli


### PR DESCRIPTION
Over in #363, I see the `Build and Deploy` CI job failing like this:

```text
Running Sphinx v7.3.5

Extension error:
Could not import extension sphinx.builders.changes (exception: No module named 'tomli')
make: *** [Makefile:20: dirhtml] Error 2
Error: Process completed with exit code 2.
```

Looks like we're getting a version of `sphinx` that doesn't declare its dependency on `tomli`.

That was just added 16 hours ago, in v7.3.5: https://github.com/sphinx-doc/sphinx/commit/8a944ac87c1fb443ab4b9d08bae3a9318d164bbf.

But the didn't make it into the `conda-forge` recipe: https://github.com/conda-forge/sphinx-feedstock/blob/512d4800c1d3e054ac23724dcab3fe620be3f0eb/recipe/meta.yaml#L21

This proposes explicitly adding `tomli` to the conda env here to unblock CI.

### Notes for Reviewers

I'll go put up a PR on the `conda-forge` recipe for `sphinx` to add that dependency on `tomli`, but we don't need to wait for that here.