### PR TITLE
ensure all notebook Python cells are valid Python code

### DIFF
--- a/source/examples/rapids-sagemaker-higgs/notebook.ipynb
+++ b/source/examples/rapids-sagemaker-higgs/notebook.ipynb
@@ -1002,7 +1002,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "aws ecr delete-repository --force --repository-name"
+    "!aws ecr delete-repository --force --repository-name"
    ]
   }
  ],

--- a/source/examples/xgboost-azure-mnmg-daskcloudprovider/notebook.ipynb
+++ b/source/examples/xgboost-azure-mnmg-daskcloudprovider/notebook.ipynb
@@ -8,17 +8,17 @@
      "slide_type": ""
     },
     "tags": [
-        "cloud/azure/azure-vm-multi",
-        "tools/dask-cloudprovider",
-        "library/cudf",
-        "library/cuml",
-        "library/xgboost",
-        "library/dask",
-        "library/fil",
-        "data-storage/azure-data-lake",
-        "dataset/nyc-taxi",
-        "workflow/xgboost"
-       ]
+     "cloud/azure/azure-vm-multi",
+     "tools/dask-cloudprovider",
+     "library/cudf",
+     "library/cuml",
+     "library/xgboost",
+     "library/dask",
+     "library/fil",
+     "data-storage/azure-data-lake",
+     "dataset/nyc-taxi",
+     "workflow/xgboost"
+    ]
    },
    "source": [
     "# Multi-Node Multi-GPU XGBoost example on Azure using dask-cloudprovider\n",
@@ -207,7 +207,7 @@
    "source": [
     "In this method, we can use an Azure marketplace VM provided by NVIDIA for free. These VM images contain all the necessary dependencies and NVIDIA drivers preinstalled. These images are made available by NVIDIA as an out-of-the-box solution to decrease the cluster setup time for data scientists. Fortunately for us, `dask-cloudprovider` has made it simple to pass in information of a marketplace VM, and it will use the selected VM image instead of a vanilla image. \n",
     "\n",
-    "We will use the following image -->  [NVIDIA GPU-Optimized Image for AI and HPC](https://azuremarketplace.microsoft.com/en-us/marketplace/apps/nvidia.ngc_azure_17_11?tab=overview).\n",
+    "We will use the following image: [NVIDIA GPU-Optimized Image for AI and HPC](https://azuremarketplace.microsoft.com/en-us/marketplace/apps/nvidia.ngc_azure_17_11?tab=overview).\n",
     "\n",
     "```{note}\n",
     "Please make sure you have [dask-cloudprovider](https://cloudprovider.dask.org/en/latest/) version 2021.6.0 or above. Marketplace VMs in Azure is not supported in older versions.\n",
@@ -403,34 +403,39 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "custom_vm_image_name = \"FILL-THIS-IN\"\n",
     "packer_config = {\n",
-    "  \"builders\": [{\n",
-    "    \"type\": \"azure-arm\",\n",
-    "    \"use_azure_cli_auth\": True,\n",
-    "    \"managed_image_resource_group_name\": resource_group,\n",
-    "    \"managed_image_name\": <the name of the customized VM image>,\n",
-    "    \"custom_data_file\": \"./configs/cloud_init.yaml.j2\",\n",
-    "    \"os_type\": \"Linux\",\n",
-    "    \"image_publisher\": \"Canonical\",\n",
-    "    \"image_offer\": \"UbuntuServer\",\n",
-    "    \"image_sku\": \"18.04-LTS\",\n",
-    "    \"azure_tags\": {\n",
-    "        \"dept\": \"RAPIDS-CSP\",\n",
-    "        \"task\": \"RAPIDS Custom Image deployment\"\n",
-    "    },\n",
-    "    \"build_resource_group_name\": resource_group,\n",
-    "    \"vm_size\": vm_size\n",
-    "  }],\n",
-    "  \"provisioners\": [{\n",
-    "    \"inline\": [\n",
-    "      \"echo 'Waiting for cloud-init'; while [ ! -f /var/lib/cloud/instance/boot-finished ]; do sleep 1; done; echo 'Done'\",\n",
+    "    \"builders\": [\n",
+    "        {\n",
+    "            \"type\": \"azure-arm\",\n",
+    "            \"use_azure_cli_auth\": True,\n",
+    "            \"managed_image_resource_group_name\": resource_group,\n",
+    "            \"managed_image_name\": custom_vm_image_name,\n",
+    "            \"custom_data_file\": \"./configs/cloud_init.yaml.j2\",\n",
+    "            \"os_type\": \"Linux\",\n",
+    "            \"image_publisher\": \"Canonical\",\n",
+    "            \"image_offer\": \"UbuntuServer\",\n",
+    "            \"image_sku\": \"18.04-LTS\",\n",
+    "            \"azure_tags\": {\n",
+    "                \"dept\": \"RAPIDS-CSP\",\n",
+    "                \"task\": \"RAPIDS Custom Image deployment\",\n",
+    "            },\n",
+    "            \"build_resource_group_name\": resource_group,\n",
+    "            \"vm_size\": vm_size,\n",
+    "        }\n",
     "    ],\n",
-    "    \"type\": \"shell\"\n",
-    "  }]\n",
+    "    \"provisioners\": [\n",
+    "        {\n",
+    "            \"inline\": [\n",
+    "                \"echo 'Waiting for cloud-init'; while [ ! -f /var/lib/cloud/instance/boot-finished ]; do sleep 1; done; echo 'Done'\",\n",
+    "            ],\n",
+    "            \"type\": \"shell\",\n",
+    "        }\n",
+    "    ],\n",
     "}\n",
     "\n",
     "with open(\"packer_config.json\", \"w\") as fh:\n",
-    "    fh.write(json.dumps(packer_config))\n"
+    "    fh.write(json.dumps(packer_config))"
    ]
   },
   {
@@ -583,7 +588,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ManagedImageId = <value from the output above> # or the customized VM id if you already have resource id of the customized VM from a previous run.\n"
+    "# fill this in with the value from above\n",
+    "# or the customized VM id if you already have resource id of the customized VM from a previous run.\n",
+    "ManagedImageId = \"FILL-THIS-IN\""
    ]
   },
   {


### PR DESCRIPTION
Contributes to #333

`ruff` reports 2 errors of the form "this Python cell in a notebook doesn't look like syntactically-valid Python code".

```text
error: Failed to parse source/examples/xgboost-azure-mnmg-daskcloudprovider/notebook.ipynb:23:6:27: Unexpected token '<'
error: Failed to parse source/examples/rapids-sagemaker-higgs/notebook.ipynb:39:1:5: Unexpected token 'ecr'
```

This fixes both of those.

### Benefits of this change

Ensuring every Python code is syntactically-valid Python code means we can get better coverage from static analysis and formatting tools, reducing the risk of bugs making it into these notebooks.

### Notes for Reviewers

I've left comments inline in the diff below explaining how specific changes fix these errors.

All other style changes were made automatically by this project's other formatting hooks. Those probably never made it onto `main` before because of similar parsing issues.