### PR TITLE
remove unused imports in XGBoost notebooks, fix other small style things

### DIFF
--- a/source/examples/rapids-1brc-single-node/notebook.ipynb
+++ b/source/examples/rapids-1brc-single-node/notebook.ipynb
@@ -204,7 +204,7 @@
     ")  # Load our lookup table of stations and their mean temperatures\n",
     "std = 10.0  # We assume temperatures are normally distributed with a standard deviation of 10\n",
     "chunksize = 2e8  # Set the number of rows to generate in one go (reduce this if you run into GPU RAM limits)\n",
-    "filename = Path(f\"measurements.txt\")  # Choose where to write to\n",
+    "filename = Path(\"measurements.txt\")  # Choose where to write to\n",
     "filename.unlink() if filename.exists() else None  # Delete the file if it exists already"
    ]
   },

--- a/source/examples/time-series-forecasting-with-hpo/notebook.ipynb
+++ b/source/examples/time-series-forecasting-with-hpo/notebook.ipynb
@@ -315,11 +315,8 @@
     "\n",
     "\n",
     "def report_dataframe_size(df, name):\n",
-    "    print(\n",
-    "        \"{} takes up {} memory on GPU\".format(\n",
-    "            name, sizeof_fmt(grid_df.memory_usage(index=True).sum())\n",
-    "        )\n",
-    "    )"
+    "    mem_usage = sizeof_fmt(grid_df.memory_usage(index=True).sum())\n",
+    "    print(f\"{name} takes up {mem_usage} memory on GPU\")"
    ]
   },
   {
@@ -6150,7 +6147,7 @@
     "          This parameter can be set to None to indicate that we shouldn't filter by dept_id.\n",
     "    \"\"\"\n",
     "    if store is None:\n",
-    "        raise ValueError(f\"store parameter must not be None\")\n",
+    "        raise ValueError(\"store parameter must not be None\")\n",
     "\n",
     "    if dept is None:\n",
     "        grid1 = grid_df[grid_df[\"store_id\"] == store]\n",

--- a/source/examples/xgboost-dask-databricks/notebook.ipynb
+++ b/source/examples/xgboost-dask-databricks/notebook.ipynb
@@ -135,14 +135,14 @@
     "import os\n",
     "from typing import Tuple\n",
     "\n",
-    "import numpy as np\n",
     "import dask_cudf\n",
     "import dask_databricks\n",
     "import dask_deltatable as ddt\n",
+    "import numpy as np\n",
     "import xgboost as xgb\n",
-    "from xgboost import dask as dxgb\n",
     "from dask_ml.model_selection import train_test_split\n",
-    "from distributed import wait"
+    "from distributed import wait\n",
+    "from xgboost import dask as dxgb"
    ]
   },
   {

--- a/source/examples/xgboost-gpu-hpo-job-parallel-k8s/notebook.ipynb
+++ b/source/examples/xgboost-gpu-hpo-job-parallel-k8s/notebook.ipynb
@@ -392,10 +392,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sklearn.datasets import load_breast_cancer\n",
-    "from sklearn.model_selection import cross_val_score, KFold\n",
     "import xgboost as xgb\n",
     "from optuna.samplers import RandomSampler\n",
+    "from sklearn.datasets import load_breast_cancer\n",
+    "from sklearn.model_selection import KFold, cross_val_score\n",
     "\n",
     "\n",
     "def objective(trial):\n",

--- a/source/examples/xgboost-gpu-hpo-job-parallel-ngc/notebook.ipynb
+++ b/source/examples/xgboost-gpu-hpo-job-parallel-ngc/notebook.ipynb
@@ -1646,10 +1646,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sklearn.datasets import load_breast_cancer\n",
-    "from sklearn.model_selection import cross_val_score, KFold\n",
     "import xgboost as xgb\n",
     "from optuna.samplers import RandomSampler\n",
+    "from sklearn.datasets import load_breast_cancer\n",
+    "from sklearn.model_selection import KFold, cross_val_score\n",
     "\n",
     "\n",
     "def objective(trial):\n",

--- a/source/examples/xgboost-randomforest-gpu-hpo-dask/notebook.ipynb
+++ b/source/examples/xgboost-randomforest-gpu-hpo-dask/notebook.ipynb
@@ -97,27 +97,20 @@
    },
    "outputs": [],
    "source": [
-    "import time\n",
+    "import os\n",
+    "from urllib.request import urlretrieve\n",
     "\n",
     "import cudf\n",
-    "import cuml\n",
+    "import dask_ml.model_selection as dcv\n",
     "import numpy as np\n",
     "import pandas as pd\n",
     "import xgboost as xgb\n",
-    "\n",
-    "import dask_ml.model_selection as dcv\n",
-    "from dask.distributed import Client, wait\n",
-    "from dask_cuda import LocalCUDACluster\n",
-    "\n",
-    "from sklearn import datasets\n",
-    "from sklearn.metrics import make_scorer\n",
     "from cuml.ensemble import RandomForestClassifier\n",
-    "from cuml.model_selection import train_test_split\n",
     "from cuml.metrics.accuracy import accuracy_score\n",
-    "\n",
-    "import os\n",
-    "from urllib.request import urlretrieve\n",
-    "import gzip"
+    "from cuml.model_selection import train_test_split\n",
+    "from dask.distributed import Client\n",
+    "from dask_cuda import LocalCUDACluster\n",
+    "from sklearn.metrics import make_scorer"
    ]
   },
   {
@@ -425,9 +418,7 @@
     "        print(\"Unknown Option, please choose one of [gpu-grid, gpu-random]\")\n",
     "        return None, None\n",
     "    res = clf.fit(X, y)\n",
-    "    print(\n",
-    "        \"Best clf and score {} {}\\n---\\n\".format(res.best_estimator_, res.best_score_)\n",
-    "    )\n",
+    "    print(f\"Best clf and score {res.best_estimator_} {res.best_score_}\\n---\\n\")\n",
     "    return res.best_estimator_, res"
    ]
   },
@@ -446,7 +437,7 @@
     "    \"\"\"\n",
     "    y_pred = model.fit(X_train, y_train).predict(X_test)\n",
     "    score = accuracy_score(y_pred, y_test.astype(\"float32\"), convert_dtype=True)\n",
-    "    print(\"{} model accuracy: {}\".format(mode_str, score))"
+    "    print(f\"{mode_str} model accuracy: {score}\")"
    ]
   },
   {
@@ -552,7 +543,8 @@
     "        mode=mode,\n",
     "        n_iter=N_ITER,\n",
     "    )\n",
-    "print(\"Searched over {} parameters\".format(len(results.cv_results_[\"mean_test_score\"])))"
+    "num_params = len(results.cv_results_[\"mean_test_score\"])\n",
+    "print(f\"Searched over {num_params} parameters\")"
    ]
   },
   {
@@ -580,7 +572,8 @@
     "    res, results = do_HPO(\n",
     "        model_gpu_xgb, params_xgb, cuml_accuracy_scorer, X_train, y_cpu, mode=mode\n",
     "    )\n",
-    "print(\"Searched over {} parameters\".format(len(results.cv_results_[\"mean_test_score\"])))"
+    "num_params = len(results.cv_results_[\"mean_test_score\"])\n",
+    "print(f\"Searched over {num_params} parameters\")"
    ]
   },
   {
@@ -721,7 +714,8 @@
     "        mode=mode,\n",
     "        n_iter=N_ITER,\n",
     "    )\n",
-    "print(\"Searched over {} parameters\".format(len(results.cv_results_[\"mean_test_score\"])))"
+    "num_params = len(results.cv_results_[\"mean_test_score\"])\n",
+    "print(f\"Searched over {num_params} parameters\")"
    ]
   },
   {


### PR DESCRIPTION
Contributes to #333

Fixes the following warnings by `ruff`

```text
source/examples/rapids-1brc-single-node/notebook.ipynb:cell 7:1:1: I001 [*] Import block is un-sorted or un-formatted
source/examples/rapids-1brc-single-node/notebook.ipynb:cell 10:8:17: F541 [*] f-string without any placeholders
source/examples/time-series-forecasting-with-hpo/notebook.ipynb:cell 23:18:9: UP032 [*] Use f-string instead of `format` call
source/examples/time-series-forecasting-with-hpo/notebook.ipynb:cell 103:12:26: F541 [*] f-string without any placeholders
source/examples/xgboost-randomforest-gpu-hpo-dask/notebook.ipynb:cell 3:1:1: I001 [*] Import block is un-sorted or un-formatted
source/examples/xgboost-randomforest-gpu-hpo-dask/notebook.ipynb:cell 3:4:8: F401 [*] `cuml` imported but unused
source/examples/xgboost-randomforest-gpu-hpo-dask/notebook.ipynb:cell 3:10:38: F401 [*] `dask.distributed.wait` imported but unused
source/examples/xgboost-randomforest-gpu-hpo-dask/notebook.ipynb:cell 3:13:21: F401 [*] `sklearn.datasets` imported but unused
source/examples/xgboost-randomforest-gpu-hpo-dask/notebook.ipynb:cell 3:21:8: F401 [*] `gzip` imported but unused
source/examples/xgboost-randomforest-gpu-hpo-dask/notebook.ipynb:cell 11:1:8: F811 [*] Redefinition of unused `time` from cell 3, line 1
source/examples/xgboost-randomforest-gpu-hpo-dask/notebook.ipynb:cell 19:27:9: UP032 [*] Use f-string instead of `format` call
source/examples/xgboost-randomforest-gpu-hpo-dask/notebook.ipynb:cell 20:8:11: UP032 [*] Use f-string instead of `format` call
source/examples/xgboost-dask-databricks/notebook.ipynb:cell 4:1:1: I001 [*] Import block is un-sorted or un-formatted
source/examples/xgboost-gpu-hpo-job-parallel-k8s/notebook.ipynb:cell 20:1:1: I001 [*] Import block is un-sorted or un-formatted
source/examples/xgboost-gpu-hpo-job-parallel-ngc/notebook.ipynb:cell 14:1:1: I001 [*] Import block is un-sorted or un-formatted
```

### How I tested this

Wherever imports were removed, searched through the notebook to be sure they weren't referenced in commented-out code or code in markdown blocks.