### PR TITLE
remove references to Pascal

### DIFF
--- a/source/cloud/aws/ecs.md
+++ b/source/cloud/aws/ecs.md
@@ -40,7 +40,7 @@ For Networking, select the default VPC and all the subnets available in that VPC
 Select "Amazon EC2 instances" for the Infrastructure type and configure your settings:
 
 - Operating system: must be Linux-based architecture
-- EC2 instance type: must support RAPIDS-compatible GPUs (Pascal or greater), e.g `p3.2xlarge`
+- EC2 instance type: must support RAPIDS-compatible GPUs ([see the RAPIDS docs](https://docs.rapids.ai/install#system-req))
 - Desired capacity: number of maximum instances to launch (default maximum 5)
 - SSH Key pair
 

--- a/source/cloud/aws/sagemaker.md
+++ b/source/cloud/aws/sagemaker.md
@@ -12,7 +12,7 @@ To get started head to SageMaker and create a [new SageMaker Notebook Instance](
 
 ### Select your instance
 
-Select a [RAPIDS compatible GPU](https://medium.com/dropout-analytics/which-gpus-work-with-rapids-ai-f562ef29c75f) (NVIDIA Pascal or greater with compute capability 6.0+) as the SageMaker Notebook instance type (e.g., `ml.p3.2xlarge`).
+Select a RAPIDS-compatible GPU ([see the RAPIDS docs](https://docs.rapids.ai/install#system-req)) as the SageMaker Notebook instance type (e.g., `ml.p3.2xlarge`).
 
 ![Screenshot of the create new notebook screen with a ml.p3.2xlarge selected](../../images/sagemaker-create-notebook-instance.png)
 

--- a/source/examples/rapids-azureml-hpo/notebook.ipynb
+++ b/source/examples/rapids-azureml-hpo/notebook.ipynb
@@ -173,11 +173,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`size` describes the virtual machine type and size that will be used in the cluster. RAPIDS requires NVIDIA Pascal or newer architecture, so \n",
-    "you will need to select compute targets from one of the  \n",
-    "[GPU virtual machines in Azure](https://docs.microsoft.com/en-us/azure/virtual-machines/sizes-gpu) provisioned with P40 and V100 GPUs : `NC_v2`, `NC_v3`, `ND` or `ND_v2` \n",
+    "`size` describes the virtual machine type and size that will be used in the cluster. See \"System Requirements\" in the RAPIDS docs ([link](https://docs.rapids.ai/install#system-req)) and \"GPU optimized virtual machine sizes\" in the Azure docs ([link](https://learn.microsoft.com/en-us/azure/virtual-machines/sizes-gpu)) to identify an instance type.\n",
     "\n",
-    "Let's create an `AmlCompute` cluster of `Standard_NC12s_v3` GPU VMs:"
+    "Let's create an `AmlCompute` cluster of `Standard_NC12s_v3` (Tesla V100) GPU VMs:"
    ]
   },
   {


### PR DESCRIPTION
Contributes to #375.
Related to https://github.com/rapidsai/docker/issues/680#issuecomment-2147695884.

There are a few lingering references in deployment docs claiming that RAPIDS supports Pascal GPUs. This proposes:

* updating those
* replacing such references with links out to the RAPIDS docs, to prevent this happening again in the future

## Notes for Reviewers

Found these like this:

```shell
git grep -i pascal
```