### PR TITLE
update versions of dependencies

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-variant: Mambaforge
           use-mamba: true

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,8 +9,8 @@ jobs:
     name: "pre-commit hooks"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
-      - uses: pre-commit/action@v2.0.0
+          python-version: "3.11"
+      - uses: pre-commit/action@v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/psf/black
-    rev: 24.4.0
+    rev: 24.4.2
     hooks:
       - id: black-jupyter
         # It is recommended to specify the latest version of Python
@@ -11,7 +11,7 @@ repos:
         # https://pre-commit.com/#top_level-default_language_version
         language_version: python3.9
   - repo: https://github.com/adamchainz/blacken-docs
-    rev: 1.16.0 # replace with latest tag on GitHub
+    rev: 1.18.0 # replace with latest tag on GitHub
     hooks:
       - id: blacken-docs
         additional_dependencies:
@@ -22,13 +22,13 @@ repos:
     hooks:
       - id: prettier
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.39.0
+    rev: v0.41.0
     hooks:
       - id: markdownlint
         args: [--ignore-path=.markdownlintignore]
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     # Ruff version.
-    rev: "v0.4.1"
+    rev: "v0.5.4"
     hooks:
       - id: ruff
         types_or: [jupyter, python]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,20 +5,15 @@ repos:
     rev: 24.4.2
     hooks:
       - id: black-jupyter
-        # It is recommended to specify the latest version of Python
-        # supported by your project here, or alternatively use
-        # pre-commit's default_language_version, see
-        # https://pre-commit.com/#top_level-default_language_version
-        language_version: python3.9
   - repo: https://github.com/adamchainz/blacken-docs
-    rev: 1.18.0 # replace with latest tag on GitHub
+    rev: 1.18.0
     hooks:
       - id: blacken-docs
         additional_dependencies:
           - black==23.1.0
         args: [--skip-errors]
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: "v4.0.0-alpha.8" # Use the sha or tag you want to point at
+    rev: "v4.0.0-alpha.8"
     hooks:
       - id: prettier
   - repo: https://github.com/igorshubovych/markdownlint-cli
@@ -27,8 +22,9 @@ repos:
       - id: markdownlint
         args: [--ignore-path=.markdownlintignore]
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    # Ruff version.
     rev: "v0.5.4"
     hooks:
       - id: ruff
         types_or: [jupyter, python]
+default_language_version:
+  python: python3

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,9 +1,9 @@
 version: 2
 
 build:
-  os: "ubuntu-20.04"
+  os: "ubuntu-lts-latest"
   tools:
-    python: "mambaforge-4.10"
+    python: "mambaforge-latest"
 
 conda:
   environment: conda/environments/deployment_docs.yml

--- a/conda/environments/deployment_docs.yml
+++ b/conda/environments/deployment_docs.yml
@@ -3,16 +3,16 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - myst-nb
-  - myst-parser
-  - nbsphinx
-  - numpydoc
+  - myst-nb>=1.1.1
+  - myst-parser>=3.0.1
+  - nbsphinx>=0.9.4
+  - numpydoc>=1.7.0
   - pydata-sphinx-theme>=0.12.0
-  - python=3.9
-  - pre-commit
-  - sphinx
-  - sphinx-autobuild
-  - sphinx-copybutton
-  - sphinx-design
-  - sphinxcontrib-mermaid
-  - python-frontmatter
+  - python=3.11
+  - pre-commit>=3.7.1
+  - sphinx>=7.4.0
+  - sphinx-autobuild>=2024.4.16
+  - sphinx-copybutton>=0.5.2
+  - sphinx-design>=0.6.0
+  - sphinxcontrib-mermaid>=0.9.2
+  - python-frontmatter>=1.1.0


### PR DESCRIPTION
In preparation for the 24.08 release, proposes updating various versions across the repo.

* updating `pre-commit` hooks via `pre-commit autodupate`
* putting floors on all dependencies in the docs-building conda environment
  - *(to make `conda` solves faster, and to prevent weird solves from accidentally rolling us back to, for example, much older versions of `sphinx`)*
* using `os: "ubuntu-lts-latest"` and `python: "mambaforge-latest"` readthedocs configs
  - *to avoid the need to make any manual changes here when Ubuntu or `mambaforge` versions go end-of-life*
  - *docs: https://docs.readthedocs.io/en/stable/config-file/v2.html#build-os*
* updating various third-party GitHub Actions to their latest versions

## Benefits of these changes

Makes CI a bit faster.

Improves the likelihood of `pre-commit` hooks catching issues.

Resolves these warnings from GitHub Actions:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v2, actions/setup-python@v2, pre-commit/action@v2.0.0. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

> The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2, actions/setup-python@v2, pre-commit/action@v2.0.0. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

([example build where you can see the warnings](https://github.com/rapidsai/deployment/actions/runs/9678951985))