### PR TITLE
remove references to rapidsai-core in dask-operator docs

### DIFF
--- a/source/tools/kubernetes/dask-operator.md
+++ b/source/tools/kubernetes/dask-operator.md
@@ -182,7 +182,7 @@ spec:
     # ...
 ```
 
-Inside our pod spec we are configuring one container that uses the `rapidsai/rapidsai-core` container image.
+Inside our pod spec we are configuring one container that uses the `rapidsai/base` container image.
 It also sets the `args` to start the `dask-cuda-worker` and configures one NVIDIA GPU.
 
 #### Scheduler
@@ -225,7 +225,7 @@ spec:
       # ...
 ```
 
-For the scheduler pod we are also setting the `rapidsai/rapidsai-core` container image, mainly to ensure our Dask versions match between
+For the scheduler pod we are also setting the `rapidsai/base` container image, mainly to ensure our Dask versions match between
 the scheduler and workers. We also disable Jupyter and ensure that the `dask-scheduler` command is configured.
 
 Then we configure both the Dask communication port on `8786` and the Dask dashboard on `8787` and add some probes so that Kubernetes can monitor


### PR DESCRIPTION
Contributes to #382.

Replaces 2 references to `rapidsai/rapidsai-core` container images with `rapidsai/base`.

These are in a doc where `rapidsai/base` has already been getting templated in for a while:

https://github.com/rapidsai/deployment/blob/3ee5b951b1b00b8abddc976d2ddd640bc84055e5/source/tools/kubernetes/dask-operator.md#L76

https://github.com/rapidsai/deployment/blob/3ee5b951b1b00b8abddc976d2ddd640bc84055e5/source/conf.py#L30