### PR TITLE
update DockerHub link in Higgs notebook

### DIFF
--- a/source/examples/rapids-sagemaker-higgs/notebook.ipynb
+++ b/source/examples/rapids-sagemaker-higgs/notebook.ipynb
@@ -136,7 +136,7 @@
    "source": [
     "### Download latest RAPIDS container from DockerHub\n",
     "\n",
-    "To build our RAPIDS Docker container compatible with Amazon SageMaker, you’ll start with base RAPIDS container, which the nice people at NVIDIA have already built and pushed to [DockerHub](https://hub.docker.com/r/rapidsai/rapidsai-core).\n",
+    "To build our RAPIDS Docker container compatible with Amazon SageMaker, you’ll start with base RAPIDS container, which the nice people at NVIDIA have already built and pushed to [DockerHub](https://hub.docker.com/r/rapidsai/base/tags).\n",
     "\n",
     "You will need to extend this container by creating a Dockerfile, copying the training script and installing [SageMaker Training toolkit](https://github.com/aws/sagemaker-training-toolkit) to makes RAPIDS compatible with SageMaker "
    ]


### PR DESCRIPTION
Contributes to #382.

The SageMaker Higgs notebook has a reference to the `rapidsai/rapidsai-core` image's DockerHub page, even though it uses `rapidsai/base`.

https://github.com/rapidsai/deployment/blob/3ee5b951b1b00b8abddc976d2ddd640bc84055e5/source/examples/rapids-sagemaker-higgs/notebook.ipynb#L153

https://github.com/rapidsai/deployment/blob/3ee5b951b1b00b8abddc976d2ddd640bc84055e5/source/conf.py#L30