### PR TITLE
run shellcheck in pre-commit checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,9 +22,13 @@ repos:
       - id: markdownlint
         args: [--ignore-path=.markdownlintignore]
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.5.4"
+    rev: "v0.5.5"
     hooks:
       - id: ruff
         types_or: [jupyter, python]
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
+    hooks:
+      - id: shellcheck
 default_language_version:
   python: python3


### PR DESCRIPTION
Proposes adding `shellcheck` to the pre-commit checks, to look for issues in shell scripts here.

This is done via `shellcheck-py` (https://pypi.org/project/shellcheck-py/), a repackaging of `shellcheck` for PyPI that allows it to be used in pre-commit without needing a separate system installation.

## Notes for Reviewers

Right now there are just 2 little shell scripts in this repo: https://github.com/search?q=repo%3Arapidsai%2Fdeployment%20path%3A**%2F*.sh&type=code

Both are used as the entrypoints in bring-your-own-container SageMaker examples. So the additional coverage we get from this check, in the current state of the repo, is pretty small.

But it's lightweight to install and runs fast, and could help to catch issues in those scripts or others we add in the future, so on balance I think it's worth adding.

### why is the `ruff` version in pre-commit changing?

As part of this, I also ran

```shell
pre-commit autoupdate
```

And that pulled in the latest version of `ruff`. Figured we might as well, while touching that file anyway.