### PR TITLE
gitignore common extensions with sensitive data, update pre-commit hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,12 @@
 *.bz2
+*.crt
 *.csv
 *.csv.gz
 *.csv.zip
+*.env
+*.pem
+*.pub
+.ruff_cache
 *.tar.gz
 *.zip
 *.7z

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/psf/black
-    rev: 24.4.2
+    rev: 24.8.0
     hooks:
       - id: black-jupyter
   - repo: https://github.com/adamchainz/blacken-docs
@@ -22,7 +22,7 @@ repos:
       - id: markdownlint
         args: [--ignore-path=.markdownlintignore]
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.5.5"
+    rev: "v0.5.6"
     hooks:
       - id: ruff
         types_or: [jupyter, python]


### PR DESCRIPTION
Just some tiny housekeeping things I noticed while working on #402.

Proposes:

* gitignore-ing extensions that often contain sensitive information, like `.env` and `.pem`
* updating pre-commit hooks to their latest versions, via `pre-commit autoupdate`