### PR TITLE
update build and test dependencies

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,5 +12,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - uses: pre-commit/action@v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,12 +17,12 @@ repos:
     hooks:
       - id: prettier
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.41.0
+    rev: v0.42.0
     hooks:
       - id: markdownlint
         args: [--ignore-path=.markdownlintignore]
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.5.6"
+    rev: "v0.6.7"
     hooks:
       - id: ruff
         types_or: [jupyter, python]

--- a/conda/environments/deployment_docs.yml
+++ b/conda/environments/deployment_docs.yml
@@ -3,16 +3,16 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - myst-nb>=1.1.1
-  - myst-parser>=3.0.1
-  - nbsphinx>=0.9.4
-  - numpydoc>=1.7.0
-  - pydata-sphinx-theme>=0.12.0
-  - python=3.11
-  - pre-commit>=3.7.1
-  - sphinx>=7.4.0
-  - sphinx-autobuild>=2024.4.16
+  - myst-nb>=1.1.2
+  - myst-parser>=4.0.0
+  - nbsphinx>=0.9.5
+  - numpydoc>=1.8.0
+  - pydata-sphinx-theme>=0.15.4
+  - python=3.12
+  - pre-commit>=3.8.0
+  - sphinx>=8.0.2
+  - sphinx-autobuild>=2024.9.19
   - sphinx-copybutton>=0.5.2
-  - sphinx-design>=0.6.0
+  - sphinx-design>=0.6.1
   - sphinxcontrib-mermaid>=0.9.2
   - python-frontmatter>=1.1.0

--- a/conda/environments/deployment_docs.yml
+++ b/conda/environments/deployment_docs.yml
@@ -1,7 +1,7 @@
 name: deployment-docs-dev
 channels:
+  - nodefaults
   - conda-forge
-  - defaults
 dependencies:
   - myst-nb>=1.1.2
   - myst-parser>=4.0.0


### PR DESCRIPTION
Since we're nearing another period of heavy activity in this project, testing the 24.10 release, this proposes updating the build and test dependencies here to their latest versions, similar to #396.

* conda env for docs building:
   - *Python `3.11 -> 3.12`*
   - *all other dependencies with floors on their latest versions (for faster conda solves)*
   - *limiting to only `conda-forge`*
* pre-commit hooks to their latest versions
  - *via `pre-commit autoupdate`
* GitHub Actions configs:
   - *Python `3.11 -> 3.12`*
   - *all third-party actions to their latest versions (no changes here, just saying I checked this)*