### PR TITLE
switch to miniforge in build-and-deploy job

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -28,10 +28,9 @@ jobs:
       - name: Set up Python
         uses: conda-incubator/setup-miniconda@v3
         with:
-          miniforge-variant: Mambaforge
-          use-mamba: true
           activate-environment: deployment-docs-dev
           environment-file: conda/environments/deployment_docs.yml
+          miniforge-version: latest
 
       - name: Build
         env:


### PR DESCRIPTION
The most recent build job on `main` failed like this:

> Warning: Future Miniforge releases will NOT build Mambaforge installers. We advise you switch to Miniforge at your earliest convenience. More details at [https://conda-forge.org/news/2024/07/29/sunsetting-mambaforge/.](https://conda-forge.org/news/2024/07/29/sunsetting-mambaforge/)
  Warning: ERROR: executing pre_install.sh failed
  
  ERROR: executing pre_install.sh failed

([build link](https://github.com/rapidsai/deployment/actions/runs/11123300853/job/30906464297))

This comes from the `conda-incubator/setup-miniconda` action. Luckily, I just experienced the same thing on a little side-project I work on (https://github.com/jameslamb/pydistcheck/pull/263)... the fix is to switch from mambaforge to miniforge.

This does that, to get builds working again here.

## Notes for Reviewers

### Shouldn't we do this in the readthedocs config?

No.

It doesn't appear that RTD supports miniforge yet, or that it's deprecated `mambaforge`: https://docs.readthedocs.io/en/stable/config-file/v2.html#build-tools-python

The only other conda option there is `miniconda`, which we'd prefer not to use (e.g. https://github.com/rapidsai/docs/pull/540)