### PR TITLE
simplify markdownlint configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,6 @@ repos:
     rev: v0.42.0
     hooks:
       - id: markdownlint
-        args: [--ignore-path=.markdownlintignore]
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: "v0.6.7"
     hooks:


### PR DESCRIPTION
#74 introduced an empty `.markdownlintignore` file, and that file appears to have been empty ever since.

I think it's safe to remove, and that doing so would slightly simplify this repo.

This proposes that removal.

## Notes for Reviewers

Let's not merge until @jacobtomlinson specifically reviews... there might be some context I'm missing that explains why this empty file was added back in #74.