### PR TITLE
remove commented-out 'autogluon' installs

### DIFF
--- a/source/cloud/aws/sagemaker.md
+++ b/source/cloud/aws/sagemaker.md
@@ -49,9 +49,6 @@ mamba create -y -n rapids {{ rapids_conda_channels }} {{ rapids_conda_packages }
 
 conda activate rapids
 
-# optionally install AutoGluon for AutoML GPU demo
-# python -m pip install --pre autogluon
-
 python -m ipykernel install --user --name rapids
 echo "kernel install completed"
 EOF

--- a/source/cloud/azure/azureml.md
+++ b/source/cloud/azure/azureml.md
@@ -57,9 +57,6 @@ conda activate rapids
 # install Python SDK v2 in rapids env
 python -m pip install azure-ai-ml azure-identity
 
-# optionally install AutoGluon for AutoML GPU demo
-# python -m pip install --pre autogluon
-
 python -m ipykernel install --user --name rapids
 echo "kernel install completed"
 EOF


### PR DESCRIPTION
Two examples have this commented-out code in setup scripts for creating development environments:

```text
# optionally install AutoGluon for AutoML GPU demo
# python -m pip install --pre autogluon
```

This proposes removing those... they seem unnecessary. I suspect they were just carried over from something else and forgotten about (e.g. the SageMaker ones came over 1.5+ years ago in #126).

There aren't any AutoML or gluon examples in this project.

```shell
git grep -i gluon
git ls-files | grep -i gluon

git grep -i automl
git ls-files | grep -i automl
```