### PR TITLE
update EC2 instructions (button text changed)

### DIFF
--- a/source/cloud/aws/ec2.md
+++ b/source/cloud/aws/ec2.md
@@ -13,7 +13,7 @@ NVIDIA maintains an [Amazon Machine Image (AMI) that pre-installs NVIDIA drivers
 1. Open the [**EC2 Dashboard**](https://console.aws.amazon.com/ec2/home).
 1. Select **Launch Instance**.
 1. In the AMI selection box search for "nvidia", then switch to the **AWS Marketplace AMIs** tab.
-1. Select **NVIDIA GPU-Optimized AMI**, then select **Select** and then **Continue**.
+1. Select **NVIDIA GPU-Optimized AMI**, then select **Subscribe on Instance Launch**.
 1. In **Key pair** select your SSH keys (create these first if you haven't already).
 1. Under network settings create a security group (or choose an existing) that allows SSH access on port `22` and also allow ports `8888,8786,8787` to access Jupyter and Dask.
 1. Select **Launch**.


### PR DESCRIPTION
Contributes to #434

The button for launching an EC2 instance using the official "NVIDIA GPU-Optimized AMI" now has language about 
"subscribing" instead of just saying "Select".

<img width="1114" alt="image" src="https://github.com/user-attachments/assets/ff13108a-ff3c-4495-a824-83d773349b7f">

Other than this, https://docs.rapids.ai/deployment/nightly/cloud/aws/ec2 is good, so I checked it off on #434