### PR TITLE
added notebook instruction

### DIFF
--- a/source/cloud/gcp/vertex-ai.md
+++ b/source/cloud/gcp/vertex-ai.md
@@ -8,7 +8,7 @@ RAPIDS can be deployed on [Vertex AI Workbench](https://cloud.google.com/vertex-
 
 ## Create a new user-managed Notebook
 
-1. From the Google Cloud UI, navigate to [**Vertex AI**](https://console.cloud.google.com/vertex-ai/workbench/user-managed) -> **Workbench**
+1. From the Google Cloud UI, navigate to [**Vertex AI**](https://console.cloud.google.com/vertex-ai/workbench/user-managed) -> Notebook -> **Workbench**
 2. Make sure you select **User-Managed Notebooks** (**Managed Notebooks** are currently not supported) and select **+ CREATE NEW**.
 3. In the **Details** section give the instance a name.
 4. Under the **Environment** section choose "Python 3 with CUDA 11.8".


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/74908110-5773-41e3-aa3b-8638de6e6c48)
I initially had trouble finding the `workbench` tab because the `NOTEBOOKS` tab was closed by default, so I was browsing through the `VERTEX AI STUDIO` tab the whole time. 
Pointing users towards the destination `workbench` tab would be easier by providing an intermediary step (the `NOTEBOOKS` tab)
![image](https://github.com/user-attachments/assets/18e0cc16-2a60-46b8-ba5f-2b481c519607)
