### PR TITLE
fixed copy code block bug

### DIFF
--- a/source/cloud/gcp/gke.md
+++ b/source/cloud/gcp/gke.md
@@ -23,9 +23,7 @@ $ gcloud init
 Now we can launch a GPU enabled GKE cluster.
 
 ```console
-$ gcloud container clusters create rapids-gpu-kubeflow \
-  --accelerator type=nvidia-tesla-a100,count=2 --machine-type a2-highgpu-2g \
-  --zone us-central1-c --release-channel stable
+$ $ gcloud container clusters create rapids-gpu-kubeflow --accelerator type=nvidia-tesla-a100,count=2 --machine-type a2-highgpu-2g --zone us-central1-c --release-channel stable
 ```
 
 With this command, you’ve launched a GKE cluster called `rapids-gpu-kubeflow`. You’ve specified that it should use nodes of type a2-highgpu-2g, each with two A100 GPUs.

--- a/source/cloud/gcp/gke.md
+++ b/source/cloud/gcp/gke.md
@@ -23,7 +23,9 @@ $ gcloud init
 Now we can launch a GPU enabled GKE cluster.
 
 ```console
-$ $ gcloud container clusters create rapids-gpu-kubeflow --accelerator type=nvidia-tesla-a100,count=2 --machine-type a2-highgpu-2g --zone us-central1-c --release-channel stable
+gcloud container clusters create rapids-gpu-kubeflow \
+  --accelerator type=nvidia-tesla-a100,count=2 --machine-type a2-highgpu-2g \
+  --zone us-central1-c --release-channel stable
 ```
 
 With this command, you’ve launched a GKE cluster called `rapids-gpu-kubeflow`. You’ve specified that it should use nodes of type a2-highgpu-2g, each with two A100 GPUs.


### PR DESCRIPTION
### Problem 
Currently the entirety of the multiline command isn't copied over when users hit the `copy` code block button (only the first line)

### Quick Fix

Turning the multiline block into a single line 

### Pros

More convenient for users to copy and paste 

### Cons

May be harder to read and interpret each of the configurations in the arguments 

