### PR TITLE
fix version in dask-cuda link

### DIFF
--- a/source/tools/dask-cuda.md
+++ b/source/tools/dask-cuda.md
@@ -1,6 +1,6 @@
 # dask-cuda
 
-[Dask-CUDA](https://docs.rapids.ai/api/dask-cuda/rapids_api_docs_version/) is a library extending `LocalCluster` from `dask.distributed` to enable multi-GPU workloads.
+[Dask-CUDA](https://docs.rapids.ai/api/dask-cuda/~~~rapids_api_docs_version~~~/) is a library extending `LocalCluster` from `dask.distributed` to enable multi-GPU workloads.
 
 ## LocalCUDACluster
 


### PR DESCRIPTION
Fixes #449

I'd thought that the templating introduced in #403 was broken, but just looks like one URL was missing the template markers. I've fixed that here.

## Notes for Reviewers

Checked for other such mistakes like this:

```shell
git grep 'rapids_api_docs_ver'
```

Didn't find any.