### PR TITLE
Alternative Dask-CloudProvider Azure Installation Command 

### DIFF
--- a/source/cloud/azure/aks.md
+++ b/source/cloud/azure/aks.md
@@ -23,7 +23,7 @@ $ az login
 Now we can launch a GPU enabled AKS cluster. First launch an AKS cluster.
 
 ```console
-$ az aks create -g <resource group> -n rapids \
+    az aks create -g <resource group> -n rapids \
         --enable-managed-identity \
         --node-count 1 \
         --enable-addons monitoring \
@@ -92,7 +92,7 @@ $ az extension add --name aks-preview
 `````
 
 ```console
-$ az aks nodepool add \
+    az aks nodepool add \
     --resource-group <resource group> \
     --cluster-name rapids \
     --name gpunp \

--- a/source/cloud/azure/azure-vm-multi.md
+++ b/source/cloud/azure/azure-vm-multi.md
@@ -12,6 +12,8 @@ Dask Cloud Provider can be installed via `conda` or `pip`. The Azure-specific ca
 $ pip install dask-cloudprovider[azure]
 ```
 
+Try running `pip install "dask-cloudprovider[azure]"` instead if you encounter a `zsh: no matches found` error.
+
 ### 2. Configure your Azure Resources
 
 Set up your [Azure Resouce Group](https://cloudprovider.dask.org/en/latest/azure.html#resource-groups), [Virtual Network](https://cloudprovider.dask.org/en/latest/azure.html#virtual-networks), and [Security Group](https://cloudprovider.dask.org/en/latest/azure.html#security-groups) according to [Dask Cloud Provider instructions](https://cloudprovider.dask.org/en/latest/azure.html#authentication).


### PR DESCRIPTION
## Problem 

Currently when trying to install Dask-CloudProvider Azure, I am getting a `no matches found` error:
![image](https://github.com/user-attachments/assets/42a1160d-1179-4ecd-8983-3080ea576e95)

## Quick Fix

After some tweaking and exploration, I tried inserting quotation marks around the package name, and that worked. 

Therefore, in this PR I propose adding a sentence in the docs that refers to this potential error and suggests users to add quotation marks if they encounter it. 