### PR TITLE
Fix EKS instructions for 24.10 testing

### DIFF
--- a/source/cloud/aws/eks.md
+++ b/source/cloud/aws/eks.md
@@ -55,7 +55,7 @@ nvidia-device-plugin-daemonset-rhmvx   1/1     Running   0          52m
 nvidia-device-plugin-daemonset-thjhc   1/1     Running   0          52m
 ```
 
-```{info}
+```{note}
 By default this plugin will install the latest version on the NVIDIA drivers on every Node. If you need more control over your driver installation we recommend that when creating your cluster you set `eksctl create cluster --install-nvidia-plugin=false ...` and then install drivers yourself using the [NVIDIA GPU Operator](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/getting-started.html).
 ```
 

--- a/source/cloud/aws/eks.md
+++ b/source/cloud/aws/eks.md
@@ -24,7 +24,7 @@ Now we can launch a GPU enabled EKS cluster. First launch an EKS cluster with `e
 
 ```console
 $ eksctl create cluster rapids \
-                      --version 1.24 \
+                      --version 1.29 \
                       --nodes 3 \
                       --node-type=p3.8xlarge \
                       --timeout=40m \
@@ -32,8 +32,7 @@ $ eksctl create cluster rapids \
                       --ssh-public-key <public key ID> \  # Be sure to set your public key ID here
                       --region us-east-1 \
                       --zones=us-east-1c,us-east-1b,us-east-1d \
-                      --auto-kubeconfig \
-                      --install-nvidia-plugin=false
+                      --auto-kubeconfig
 ```
 
 With this command, you’ve launched an EKS cluster called `rapids`. You’ve specified that it should use nodes of type `p3.8xlarge`. We also specified that we don't want to install the NVIDIA drivers as we will do that with the NVIDIA operator.
@@ -46,30 +45,21 @@ $ aws eks --region us-east-1 update-kubeconfig --name rapids
 
 ## Install drivers
 
-Next, [install the NVIDIA drivers](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/getting-started.html) onto each node.
+As we selected a GPU node type EKS will automatically install drivers for us. We can verify this by listing the NVIDIA driver plugin Pods.
 
 ```console
-$ helm install --repo https://helm.ngc.nvidia.com/nvidia --wait --generate-name -n gpu-operator --create-namespace gpu-operator
-NAME: gpu-operator-1670843572
-NAMESPACE: gpu-operator
-STATUS: deployed
-REVISION: 1
-TEST SUITE: None
+$ kubectl get po -n kube-system -l name=nvidia-device-plugin-ds
+NAME                                   READY   STATUS    RESTARTS   AGE
+nvidia-device-plugin-daemonset-kv7t5   1/1     Running   0          52m
+nvidia-device-plugin-daemonset-rhmvx   1/1     Running   0          52m
+nvidia-device-plugin-daemonset-thjhc   1/1     Running   0          52m
 ```
 
-Verify that the NVIDIA drivers are successfully installed.
-
-```console
-$ kubectl get po -A --watch | grep nvidia
-kube-system   nvidia-driver-installer-6zwcn                                 1/1     Running   0         8m47s
-kube-system   nvidia-driver-installer-8zmmn                                 1/1     Running   0         8m47s
-kube-system   nvidia-driver-installer-mjkb8                                 1/1     Running   0         8m47s
-kube-system   nvidia-gpu-device-plugin-5ffkm                                1/1     Running   0         13m
-kube-system   nvidia-gpu-device-plugin-d599s                                1/1     Running   0         13m
-kube-system   nvidia-gpu-device-plugin-jrgjh                                1/1     Running   0         13m
+```{info}
+By default this plugin will install the latest version on the NVIDIA drivers on every Node. If you need more control over your driver installation we recommend that when creating your cluster you set `eksctl create cluster --install-nvidia-plugin=false ...` and then install drivers yourself using the [NVIDIA GPU Operator](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/getting-started.html).
 ```
 
-After your drivers are installed, you are ready to test your cluster.
+After you have confirmed your drivers are installed, you are ready to test your cluster.
 
 ```{include} ../../_includes/check-gpu-pod-works.md
 


### PR DESCRIPTION
It seems that a lot of the issues we were having were related to using the NVIDIA GPU Operator on EKS with Amazon Linux nodes. To simplify things I've updated the docs to just use the default driver install that EKS does for you. This gives you much less control than the GPU Operator, but should be more than suitable for beginners.

This allows us to simplify the docs here and get things working OOTB again.

Closes #409 
Closes #459