### PR TITLE
Add upper bound pin temporarily to sphinx to avoid breakages

### DIFF
--- a/conda/environments/deployment_docs.yml
+++ b/conda/environments/deployment_docs.yml
@@ -10,7 +10,8 @@ dependencies:
   - pydata-sphinx-theme>=0.15.4
   - python=3.12
   - pre-commit>=3.8.0
-  - sphinx>=8.0.2
+  # Upper bound pin on sphinx can be removed once https://github.com/mgaitan/sphinxcontrib-mermaid/issues/160 is resolved
+  - sphinx>=8.0.2,<8.1
   - sphinx-autobuild>=2024.9.19
   - sphinx-copybutton>=0.5.2
   - sphinx-design>=0.6.1


### PR DESCRIPTION
Looks like sphinx 8.1.0 broke `sphinxcontrib-mermaid` which in turn broke builds here. Adding an upper bound pin to sphinx until this is resolved.

I've also opened https://github.com/mgaitan/sphinxcontrib-mermaid/pull/161 to contribute a fix upstream which will allow us to remove the upper bound again.

Closes #463 