### PR TITLE
Amend Coiled cluster example on Jupyter

### DIFF
--- a/source/platforms/coiled.md
+++ b/source/platforms/coiled.md
@@ -82,7 +82,7 @@ We can also connect a Dask client to see that information for the workers too.
 ```python
 from dask.distributed import Client
 
-client = Client(cluster)
+client = Client()
 client
 ```
 


### PR DESCRIPTION
Based on discussion in https://github.com/rapidsai/deployment/pull/456#discussion_r1796927267, sounds like this example shouldn't include `cluster` as an argument to `Client` as this should be implicitly picked up from within a Jupyter server spun up as part of a Coiled cluster.