### PR TITLE
Added Feedback Link to Sidebar

### DIFF
--- a/source/_templates/feedback.html
+++ b/source/_templates/feedback.html
@@ -1,0 +1,10 @@
+<p>
+  <i class="fa-solid fa-pencil"></i>
+  Spotted a mistake?
+  <br />
+  <a
+    href="https://github.com/rapidsai/deployment/issues/new?template=Blank+issue"
+  >
+    Let us know!
+  </a>
+</p>

--- a/source/conf.py
+++ b/source/conf.py
@@ -114,6 +114,7 @@ html_theme_options = {
         "page-toc",
         "notebooks-extra-files-nav",
         "notebooks-tags",
+        "feedback"
     ],
 }
 


### PR DESCRIPTION
<img width="1015" alt="image" src="https://github.com/user-attachments/assets/12789c2f-4974-4b0d-8292-b58f3a8b1e1c">

Users have the option to click on the link (which leads to the new issue page in the github repository) if they spot a mistake on the docs