### PR TITLE
Add missing slash to AzureML startup script

### DIFF
--- a/source/cloud/azure/azureml.md
+++ b/source/cloud/azure/azureml.md
@@ -43,7 +43,7 @@ Put the following in a local file called `rapids-azure-startup.sh`:
 sudo -u azureuser -i <<'EOF'
 source /anaconda/etc/profile.d/conda.sh
 conda create -y -n rapids \
-    {{ rapids_conda_channels }}
+    {{ rapids_conda_channels }} \
     -c microsoft \
    {{ rapids_conda_packages }} \
     'azure-identity>=1.19' \


### PR DESCRIPTION
Looks like the conda command is failing because the lines aren't escaped correctly. This should fix things.