### PR TITLE
Ignore .ipynb_checkpoints in release checklist script

### DIFF
--- a/scripts/gen_release_checklist_issue.py
+++ b/scripts/gen_release_checklist_issue.py
@@ -40,6 +40,8 @@ for file in (script_dir.parent / "source").rglob("*"):
     if file.is_file() and file.suffix in [".ipynb", ".md"]:
         if "_includes" in file.parts:
             continue
+        if ".ipynb_checkpoints" in file.parts:
+            continue
         if "index.md" in file.parts:
             rel_path = file.parent
         else:


### PR DESCRIPTION
The last couple of releases I had to manually remove some `.ipynb_checkpoints` entries from the generated list. This PR updates the script so that they don't get included in the first place.