### PR TITLE
Fixed deployment options in Compute Engine and cluster credentials in…

### DIFF
--- a/source/cloud/aws/sagemaker.md
+++ b/source/cloud/aws/sagemaker.md
@@ -41,7 +41,7 @@ set -e
 
 sudo -u ec2-user -i <<'EOF'
 
-mamba create -y -n rapids {{ rapids_conda_channels }} {{ rapids_sagemaker_conda_packages }} \
+mamba create -y -n rapids -c rapidsai -c conda-forge -c nvidia rapids=24.12 python=3.12 cuda-version=12.4 \
     boto3 \
     ipykernel \
     'sagemaker-python-sdk>=2.239.0'

--- a/source/cloud/gcp/compute-engine.md
+++ b/source/cloud/gcp/compute-engine.md
@@ -12,6 +12,7 @@ NVIDIA maintains a [Virtual Machine Image (VMI) that pre-installs NVIDIA drivers
 
 1. Open [**Compute Engine**](https://console.cloud.google.com/compute/instances).
 1. Select **Create Instance**.
+1. Select the **Create VM from..** option at the top.
 1. Select **Marketplace**.
 1. Search for "nvidia" and select **NVIDIA GPU-Optimized VMI**, then select **Launch**.
 1. In the **New NVIDIA GPU-Optimized VMI deployment** interface, fill in the name and any required information for the vm (the defaults should be fine for most users).
@@ -29,7 +30,7 @@ To access Jupyter and Dask we will need to set up some firewall rules to open up
 3. Give the rule a name like `rapids` and ensure the network matches the one you selected for the VM.
 4. Add a tag like `rapids` which we will use to assign the rule to our VM.
 5. Set your source IP range. We recommend you restrict this to your own IP address or your corporate network rather than `0.0.0.0/0` which will allow anyone to access your VM.
-6. Under **Protocols and ports** allow TCP connections on ports `8786,8787,8888`.
+6. Under **Protocols and ports** allow TCP connections on ports `22,8786,8787,8888`.
 
 ### Assign it to the VM
 

--- a/source/cloud/gcp/gke.md
+++ b/source/cloud/gcp/gke.md
@@ -37,7 +37,7 @@ gcloud container clusters get-credentials rapids-gpu-kubeflow \
     --region=us-central1-c
 ```
 
-With this command, your `kubeconfig` is updated with credentials and endpoint information for the `rapids-gpu-kubeflow` cluster. 
+With this command, your `kubeconfig` is updated with credentials and endpoint information for the `rapids-gpu-kubeflow` cluster.
 
 ## Install drivers
 

--- a/source/cloud/gcp/gke.md
+++ b/source/cloud/gcp/gke.md
@@ -30,6 +30,15 @@ gcloud container clusters create rapids-gpu-kubeflow \
 
 With this command, you’ve launched a GKE cluster called `rapids-gpu-kubeflow`. You’ve specified that it should use nodes of type a2-highgpu-2g, each with two A100 GPUs.
 
+## Get the cluster credentials
+
+```console
+gcloud container clusters get-credentials rapids-gpu-kubeflow \
+    --region=us-central1-c
+```
+
+With this command, your `kubeconfig` is updated with credentials and endpoint information for the `rapids-gpu-kubeflow` cluster. 
+
 ## Install drivers
 
 Next, [install the NVIDIA drivers](https://cloud.google.com/kubernetes-engine/docs/how-to/gpus#installing_drivers) onto each node.


### PR DESCRIPTION
Making changes to docs based on observations from deployment testing:
1. Added the port 22 to the firewall rule to allow for SSH access on Compute Engine VM
2. Added the code snippet to get cluster credentials after creating a cluster on GKE, which is necessary for `kubectl` NVIDIA driver install
3. Pinning a working configuration for Sagemaker, which can be reverted back to templating once the Sagemaker support for  GLIBC 2.28 is up. #520 