### PR TITLE
Add missing Font Awesome css

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -160,6 +160,9 @@ redirects = {
 
 def setup(app):
     app.add_css_file("https://docs.rapids.ai/assets/css/custom.css")
+    app.add_css_file(
+        "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.9.0/css/all.min.css"
+    )
     app.add_css_file("css/custom.css")
     app.add_js_file(
         "https://docs.rapids.ai/assets/js/custom.js", loading_method="defer"


### PR DESCRIPTION
Looks like the upstream CSS got broken and we need to explicitly include font awesome now.

**Before**
<img width="467" alt="image" src="https://github.com/user-attachments/assets/8769bc9c-f78e-4ed6-b739-8bc09ef47a5e" />

**After**
<img width="481" alt="image" src="https://github.com/user-attachments/assets/136d843b-7e2c-44bb-8395-40dcad78b86d" />
