### PR TITLE
Fix styling issues in docref admonition

### DIFF
--- a/extensions/rapids_admonitions.py
+++ b/extensions/rapids_admonitions.py
@@ -12,7 +12,7 @@ class Docref(BaseAdmonition, SphinxDirective):
     def run(self):
         doc = self.arguments[0]
         self.arguments = ["See Documentation"]
-        self.options["classes"] = ["docref"]
+        self.options["classes"] = ["admonition-docref"]
         nodes = super().run()
         custom_xref = pending_xref(
             reftype="myst",

--- a/source/_static/css/custom.css
+++ b/source/_static/css/custom.css
@@ -22,18 +22,16 @@ nav.bd-links fieldset .sd-badge {
   font-size: 0.9em;
 }
 
-/* Admonitions */
-.docref {
-  border-color: var(--sd-color-primary) !important;
+div.admonition.admonition-docref {
+  border-color: var(--sd-color-primary);
 }
 
-.docref .admonition-title {
+div.admonition.admonition-docref > .admonition-title {
   color: var(--sd-color-primary-text);
   background: var(--sd-color-primary);
 }
 
-.docref > .admonition-title::after,
-div.docref > .admonition-title::after {
+div.admonition.admonition-docref > .admonition-title::after {
   color: var(--sd-color-primary-text);
   content: "\f02d";
 }

--- a/source/_static/css/custom.css
+++ b/source/_static/css/custom.css
@@ -22,6 +22,7 @@ nav.bd-links fieldset .sd-badge {
   font-size: 0.9em;
 }
 
+/* Admonitions */
 div.admonition.admonition-docref {
   border-color: var(--sd-color-primary);
 }


### PR DESCRIPTION
Closes #522 

Updates the custom admonition styling to follow the colour customisation conventions mentioned in the [PyData Sphinx Theme docs](https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/extending.html#customizing-the-color).

**Before**
<img width="1591" alt="image" src="https://github.com/user-attachments/assets/3a995b52-e1de-42a2-ba9d-12a3480f400f" />


**After** ([Live Preview](https://rapids-deployment--559.org.readthedocs.build/en/559/examples/xgboost-rf-gpu-cpu-benchmark/notebook/))
<img width="1660" alt="image" src="https://github.com/user-attachments/assets/922d9b0b-0f89-426d-aad0-9e9c18802beb" />
