### PR TITLE
Speed up unused images pre-commit hook

### DIFF
--- a/scripts/unused_images.sh
+++ b/scripts/unused_images.sh
@@ -2,12 +2,12 @@
 
 set -e -u -o pipefail
 
-imagepaths=$(find . -type f \( -iname "*.jpg" -o -iname "*.jpeg" -o -iname "*.png" -o -iname "*.gif" -o -iname "*.svg" \) ! -path "./build/*" ! -path "./node_modules/*" ! -path "./jupyter_execute/*" ! -path "./.ipynb_checkpoints/*")
+imagepaths=$(find source -type f \( -iname "*.jpg" -o -iname "*.jpeg" -o -iname "*.png" -o -iname "*.gif" -o -iname "*.svg" \) ! -path "./build/*" ! -path "./node_modules/*" ! -path "./jupyter_execute/*" ! -path "./.ipynb_checkpoints/*")
 counter=0
 
 for imagepath in $imagepaths; do
     filename=$(basename -- "$imagepath")
-    if ! grep -q -r --exclude-dir=".git" --exclude-dir="build" --exclude-dir="node_modules" --exclude-dir="jupyter_execute" --exclude-dir=".ipynb_checkpoints" "$filename" .; then
+    if ! grep -q -r --exclude-dir=".git" --exclude-dir="build" --exclude-dir="node_modules" --exclude-dir="jupyter_execute" --exclude-dir=".ipynb_checkpoints" "$filename" source README.md; then
         echo "Found unused image $imagepath"
         counter=$((counter+1))
     fi

--- a/scripts/unused_images.sh
+++ b/scripts/unused_images.sh
@@ -2,12 +2,12 @@
 
 set -e -u -o pipefail
 
-imagepaths=$(find source -type f \( -iname "*.jpg" -o -iname "*.jpeg" -o -iname "*.png" -o -iname "*.gif" -o -iname "*.svg" \) ! -path "./build/*" ! -path "./node_modules/*" ! -path "./jupyter_execute/*" ! -path "./.ipynb_checkpoints/*")
+imagepaths=$(find source -type f \( -iname "*.jpg" -o -iname "*.jpeg" -o -iname "*.png" -o -iname "*.gif" -o -iname "*.svg" \))
 counter=0
 
 for imagepath in $imagepaths; do
     filename=$(basename -- "$imagepath")
-    if ! grep -q -r --exclude-dir=".git" --exclude-dir="build" --exclude-dir="node_modules" --exclude-dir="jupyter_execute" --exclude-dir=".ipynb_checkpoints" "$filename" source README.md; then
+    if ! grep -q -r "$filename" source README.md; then
         echo "Found unused image $imagepath"
         counter=$((counter+1))
     fi


### PR DESCRIPTION
On my machine the `unused-images` pre-commit hook was taking ~35s. It seemed to be because it was traversing folders at the root level of the repo like `node_modules`. There were excludes for these but it wasn't working in the way I expected.

This PR updates the script to explicitly only check for images stored within `source/` and ensures they are referenced either in `source/` or the main `README.md`. This change reduces execution time to around 1 second.