### PR TITLE
Enable md linting breakline and apply

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,6 +1,9 @@
 {
   "default": true,
-  "MD013": false,
+  "MD013": {
+    "line_length": 120,
+    "tables": false
+  },
   "MD014": false,
   "MD029": false,
   "MD033": false,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,7 @@ repos:
     rev: v0.45.0
     hooks:
       - id: markdownlint
+        args: ["--fix"]
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: "v0.11.10"
     hooks:

--- a/README.md
+++ b/README.md
@@ -102,10 +102,14 @@ user experience and there may already be a suitable root namespace for the tag y
 By default tags are styled with RAPIDS purple backgrounds and white text. They also have a `0.5em` left hand border to
 use as an accent that is also purple by default which can be styled for a two-tone effect.
 
+<!-- markdownlint-disable -->
+
 <div style="width: 100%; text-align: center;">
-<img alt="Diagram showing the tag and css side-by-side with arrows to show color sets the text, background-color sets
-the background and border-left sets the accent" src="source/images/theme-tag-style.png" style="max-width: 450px;" />
+<img alt="Diagram showing the tag and css side-by-side with arrows to show color sets the text, background-color sets the background and border-left sets the accent"
+src="source/images/theme-tag-style.png" style="max-width: 450px;" />
 </div>
+
+<!-- markdownlint-enable -->
 
 This can be overridden for each tag by adding a new class with the format `.tag-{name}` to `source/_static/css/custom.css`.
 For example the Scikit-Learn logo is orange and blue with grey text, so the custom CSS sets an orange background with a

--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ uv lock --upgrade
 
 ## Writing
 
-Content in these docs are written in markdown using the [MyST Sphinx
-extension](https://myst-parser.readthedocs.io/en/v0.15.1/syntax/syntax.html).
+Content in these docs are written in markdown using the [MyST Sphinx extension](https://myst-parser.readthedocs.io/en/v0.15.1/syntax/syntax.html).
 
 ### Custom admonitions
 
@@ -57,8 +56,9 @@ Renders as:
 
 ![Screenshot of the rendered docref admonition](source/images/docref-admonition.png)
 
-> **Note** The `Visit the documentation >>` link is added automatically in the bottom right based on the page that is
-> referenced in the directive argument.
+> **Note**
+> The `Visit the documentation >>` link is added automatically in the bottom right based on the page that is referenced
+> in the directive argument.
 
 ### Notebooks
 
@@ -73,8 +73,7 @@ docs. This does mean there are a few assumptions about how notebooks should be w
 1. Create a new directory inside `source/examples`.
 2. Create a new notebook file in that directory and give it a name like `notebook.ipynb`.
    - The first cell of your notebook should be a markdown cell and contain at least a top level header.
-   - You can add tags to your notebook by adding [cell metadata tags to the first
-     cell](https://jupyterbook.org/en/stable/content/metadata.html).
+   - You can add tags to your notebook by adding [cell metadata tags to the first cell](https://jupyterbook.org/en/stable/content/metadata.html).
 3. Place any supporting files such as scripts, Dockerfiles, etc in the same directory. These files will be discovered
    and listed on the rendered notebook page.
 4. Update the `notebookgallerytoctree` section in `source/examples/index.md` with the relative path to your new notebook.
@@ -108,9 +107,9 @@ use as an accent that is also purple by default which can be styled for a two-to
 the background and border-left sets the accent" src="source/images/theme-tag-style.png" style="max-width: 450px;" />
 </div>
 
-This can be overridden for each tag by adding a new class with the format `.tag-{name}` to
-`source/_static/css/custom.css`. For example the Scikit-Learn logo is orange and blue with grey text, so the custom CSS
-sets an orange background with a blue accent and grey text.
+This can be overridden for each tag by adding a new class with the format `.tag-{name}` to `source/_static/css/custom.css`.
+For example the Scikit-Learn logo is orange and blue with grey text, so the custom CSS sets an orange background with a
+blue accent and grey text.
 
 ```css
 .tag-scikit-learn {

--- a/README.md
+++ b/README.md
@@ -2,12 +2,13 @@
 
 ## Building
 
-For fast and consistent builds of the documentation we recommend running all build commands with [uv](https://docs.astral.sh/uv/getting-started/installation/) and `uv run`.
-Build dependencies are stored in `pyproject.toml` and locked with `uv.lock` to ensure reproducible builds.
+For fast and consistent builds of the documentation we recommend running all build commands with
+[uv](https://docs.astral.sh/uv/getting-started/installation/) and `uv run`. Build dependencies are stored in
+`pyproject.toml` and locked with `uv.lock` to ensure reproducible builds.
 
-We also recommend building with [sphinx-autobuild](https://github.com/executablebooks/sphinx-autobuild).
-This tool will build your docs and host them on a local web server.
-It will watch for file changes, rebuild automatically and tell the browser page to reload. Magic!
+We also recommend building with [sphinx-autobuild](https://github.com/executablebooks/sphinx-autobuild). This tool will
+build your docs and host them on a local web server. It will watch for file changes, rebuild automatically and tell the
+browser page to reload. Magic!
 
 ```console
 $ uv run sphinx-autobuild source build/html
@@ -26,7 +27,8 @@ Alternatively you can build the static site into `build/html` with `sphinx`.
 uv run make dirhtml
 ```
 
-The `uv.lock` file will ensure reproducible builds, but if you want to intentionally upgrade to newer versions of dependencies you can run
+The `uv.lock` file will ensure reproducible builds, but if you want to intentionally upgrade to newer versions of
+dependencies you can run
 
 ```bash
 uv lock --upgrade
@@ -34,7 +36,8 @@ uv lock --upgrade
 
 ## Writing
 
-Content in these docs are written in markdown using the [MyST Sphinx extension](https://myst-parser.readthedocs.io/en/v0.15.1/syntax/syntax.html).
+Content in these docs are written in markdown using the [MyST Sphinx
+extension](https://myst-parser.readthedocs.io/en/v0.15.1/syntax/syntax.html).
 
 ### Custom admonitions
 
@@ -54,23 +57,26 @@ Renders as:
 
 ![Screenshot of the rendered docref admonition](source/images/docref-admonition.png)
 
-> **Note**
-> The `Visit the documentation >>` link is added automatically in the bottom right based on the page that is referenced in the directive argument.
+> **Note** The `Visit the documentation >>` link is added automatically in the bottom right based on the page that is
+> referenced in the directive argument.
 
 ### Notebooks
 
-The `examples` section of these docs are written in Jupyter Notebooks and built with [MyST-NB](https://myst-nb.readthedocs.io/en/latest/).
+The `examples` section of these docs are written in Jupyter Notebooks and built with
+[MyST-NB](https://myst-nb.readthedocs.io/en/latest/).
 
-There is also a custom Sphinx extension which shows the examples in a gallery with helpful cross linking throughout the docs. This does mean there
-are a few assumptions about how notebooks should be written.
+There is also a custom Sphinx extension which shows the examples in a gallery with helpful cross linking throughout the
+docs. This does mean there are a few assumptions about how notebooks should be written.
 
 #### Adding examples
 
 1. Create a new directory inside `source/examples`.
 2. Create a new notebook file in that directory and give it a name like `notebook.ipynb`.
    - The first cell of your notebook should be a markdown cell and contain at least a top level header.
-   - You can add tags to your notebook by adding [cell metadata tags to the first cell](https://jupyterbook.org/en/stable/content/metadata.html).
-3. Place any supporting files such as scripts, Dockerfiles, etc in the same directory. These files will be discovered and listed on the rendered notebook page.
+   - You can add tags to your notebook by adding [cell metadata tags to the first
+     cell](https://jupyterbook.org/en/stable/content/metadata.html).
+3. Place any supporting files such as scripts, Dockerfiles, etc in the same directory. These files will be discovered
+   and listed on the rendered notebook page.
 4. Update the `notebookgallerytoctree` section in `source/examples/index.md` with the relative path to your new notebook.
 
 #### Tags
@@ -79,21 +85,32 @@ The notebook gallery extension uses cell tags to organize and cross-reference fi
 
 ![Screenshot of Jupyter showing the first cell of the open notebook has tags](source/images/theme-notebook-tags.png)
 
-Tags are hierarchical and use slashes to separate their namespaces. For example if your notebook uses AWS Sagemaker you should add the tag `cloud/aws/sagemaker`. This aligns with the Sphinx doc path to the RAPIDS Sagemaker documentation page which you can find in `source/cloud/aws/sagemaker.md`.
+Tags are hierarchical and use slashes to separate their namespaces. For example if your notebook uses AWS Sagemaker you
+should add the tag `cloud/aws/sagemaker`. This aligns with the Sphinx doc path to the RAPIDS Sagemaker documentation
+page which you can find in `source/cloud/aws/sagemaker.md`.
 
-The extension will use this information to ensure the notebook is linked from the Sagemaker page under the "Related Examples" section.
+The extension will use this information to ensure the notebook is linked from the Sagemaker page under the "Related
+Examples" section.
 
-The example gallery will also allow you to filter based on these tags. The root of the tag namespace is used to create the filtering categories. So in the above example the `cloud/aws/sagemaker` tag would create a filter for `cloud` with an option of `aws/sagemaker`. You can create new filter sections simply by creating new tags with unique root namespaces, but be mindful that keeping the number of filtering sections to a minimum will provide users with the best user experience and there may already be a suitable root namespace for the tag you want to create.
+The example gallery will also allow you to filter based on these tags. The root of the tag namespace is used to create
+the filtering categories. So in the above example the `cloud/aws/sagemaker` tag would create a filter for `cloud` with
+an option of `aws/sagemaker`. You can create new filter sections simply by creating new tags with unique root
+namespaces, but be mindful that keeping the number of filtering sections to a minimum will provide users with the best
+user experience and there may already be a suitable root namespace for the tag you want to create.
 
 ##### Styling
 
-By default tags are styled with RAPIDS purple backgrounds and white text. They also have a `0.5em` left hand border to use as an accent that is also purple by default which can be styled for a two-tone effect.
+By default tags are styled with RAPIDS purple backgrounds and white text. They also have a `0.5em` left hand border to
+use as an accent that is also purple by default which can be styled for a two-tone effect.
 
 <div style="width: 100%; text-align: center;">
-<img alt="Diagram showing the tag and css side-by-side with arrows to show color sets the text, background-color sets the background and border-left sets the accent" src="source/images/theme-tag-style.png" style="max-width: 450px;" />
+<img alt="Diagram showing the tag and css side-by-side with arrows to show color sets the text, background-color sets
+the background and border-left sets the accent" src="source/images/theme-tag-style.png" style="max-width: 450px;" />
 </div>
 
-This can be overridden for each tag by adding a new class with the format `.tag-{name}` to `source/_static/css/custom.css`. For example the Scikit-Learn logo is orange and blue with grey text, so the custom CSS sets an orange background with a blue accent and grey text.
+This can be overridden for each tag by adding a new class with the format `.tag-{name}` to
+`source/_static/css/custom.css`. For example the Scikit-Learn logo is orange and blue with grey text, so the custom CSS
+sets an orange background with a blue accent and grey text.
 
 ```css
 .tag-scikit-learn {
@@ -103,13 +120,17 @@ This can be overridden for each tag by adding a new class with the format `.tag-
 }
 ```
 
-Tag styling can be added at any domain level, for example the `cloud/aws/sagemaker` tag uses the `.tag-cloud`, `.tag-aws` and `.tag-sagemaker` classes. They will be applied in that order too so we can set a default AWS style which can be overridden on a service-by-service basis.
+Tag styling can be added at any domain level, for example the `cloud/aws/sagemaker` tag uses the `.tag-cloud`,
+`.tag-aws` and `.tag-sagemaker` classes. They will be applied in that order too so we can set a default AWS style which
+can be overridden on a service-by-service basis.
 
 ## Linting
 
-This project uses [prettier](https://prettier.io/) and [markdownlint](https://github.com/DavidAnson/markdownlint) to enforce automatic formatting and consistent style as well as identify rendering issues early.
+This project uses [prettier](https://prettier.io/) and [markdownlint](https://github.com/DavidAnson/markdownlint) to
+enforce automatic formatting and consistent style as well as identify rendering issues early.
 
-It is recommended to run this automatically on each commit using [pre-commit](https://pre-commit.com/) as linting rules are enforced via CI checks and linting locally will save time in code review.
+It is recommended to run this automatically on each commit using [pre-commit](https://pre-commit.com/) as linting rules
+are enforced via CI checks and linting locally will save time in code review.
 
 ```console
 $ pre-commit install
@@ -122,11 +143,18 @@ markdownlint.............................................................Passed
 
 ## Releasing
 
-This repository is continuously deployed to the [nightly docs at docs.rapids.ai](https://docs.rapids.ai/deployment/nightly/) via the [build-and-deploy](https://github.com/rapidsai/deployment/blob/main/.github/workflows/build-and-deploy.yml) workflow. All commits to main are built to static HTML and pushed to the [`deployment/nightly` subdirectory in the rapidsai/docs repo](https://github.com/rapidsai/docs/tree/gh-pages/deployment) which in turn is published to GitHub Pages.
+This repository is continuously deployed to the [nightly docs at
+docs.rapids.ai](https://docs.rapids.ai/deployment/nightly/) via the
+[build-and-deploy](https://github.com/rapidsai/deployment/blob/main/.github/workflows/build-and-deploy.yml) workflow.
+All commits to main are built to static HTML and pushed to the [`deployment/nightly` subdirectory in the rapidsai/docs
+repo](https://github.com/rapidsai/docs/tree/gh-pages/deployment) which in turn is published to GitHub Pages.
 
-We can also update the [stable documentation at docs.rapids.ai](https://docs.rapids.ai/deployment/stable/) by creating and pushing a tag which will cause the `build-and-deploy` workflow to push to the [`deployment/stable` subdirectory](https://github.com/rapidsai/docs/tree/gh-pages/deployment) instead.
+We can also update the [stable documentation at docs.rapids.ai](https://docs.rapids.ai/deployment/stable/) by creating
+and pushing a tag which will cause the `build-and-deploy` workflow to push to the [`deployment/stable`
+subdirectory](https://github.com/rapidsai/docs/tree/gh-pages/deployment) instead.
 
-The RAPIDS versions for things like container images and install instructions are templated into the documentation pages and are stored in `source/conf.py`.
+The RAPIDS versions for things like container images and install instructions are templated into the documentation pages
+and are stored in `source/conf.py`.
 
 ```python
 versions = {
@@ -157,9 +185,13 @@ In those cases, use `~~~` with no spaces, like this:
 For more, see the docs on [dask-cuda](https://docs.rapids.ai/api/dask-cuda/~~~rapids_api_docs_version~~~/install.html)
 ```
 
-All builds will use the nightly section by default which allows you to test with the latest and greatest containers when developing locally or previewing nightly docs builds. To build the docs using the stable images you need to set the environment variable `DEPLOYMENT_DOCS_BUILD_STABLE` to `true`. This is done automatically when building from a tag in CI.
+All builds will use the nightly section by default which allows you to test with the latest and greatest containers when
+developing locally or previewing nightly docs builds. To build the docs using the stable images you need to set the
+environment variable `DEPLOYMENT_DOCS_BUILD_STABLE` to `true`. This is done automatically when building from a tag in
+CI.
 
-Before you publish a new version for a release ensure that the latest container images are available and then update the `stable` config to use the new release version and update `nightly` to use the next upcoming nightly.
+Before you publish a new version for a release ensure that the latest container images are available and then update the
+`stable` config to use the new release version and update `nightly` to use the next upcoming nightly.
 
 Then you can push a tag to release.
 

--- a/source/cloud/aws/ec2-multi.md
+++ b/source/cloud/aws/ec2-multi.md
@@ -1,20 +1,27 @@
 # EC2 Cluster (via Dask)
 
-To launch a multi-node cluster on AWS EC2 we recommend you use [Dask Cloud Provider](https://cloudprovider.dask.org/en/latest/), a native cloud integration for Dask. It helps manage Dask clusters on different cloud platforms.
+To launch a multi-node cluster on AWS EC2 we recommend you use [Dask Cloud
+Provider](https://cloudprovider.dask.org/en/latest/), a native cloud integration for Dask. It helps manage Dask clusters
+on different cloud platforms.
 
 ## Local Environment Setup
 
 Before running these instructions, ensure you have installed RAPIDS.
 
 ```{note}
-This method of deploying RAPIDS effectively allows you to burst beyond the node you are on into a cluster of EC2 VMs. This does come with the caveat that you are on a RAPIDS capable environment with GPUs.
+
+This method of deploying RAPIDS effectively allows you to burst beyond the node you are on into a cluster of EC2 VMs.
+This does come with the caveat that you are on a RAPIDS capable environment with GPUs.
 ```
 
-If you are using a machine with an NVIDIA GPU then follow the [local install instructions](https://docs.rapids.ai/install). Alternatively if you do not have a GPU locally consider using a remote environment like a [SageMaker Notebook Instance](https://docs.aws.amazon.com/sagemaker/latest/dg/nbi.html).
+If you are using a machine with an NVIDIA GPU then follow the [local install
+instructions](https://docs.rapids.ai/install). Alternatively if you do not have a GPU locally consider using a remote
+environment like a [SageMaker Notebook Instance](https://docs.aws.amazon.com/sagemaker/latest/dg/nbi.html).
 
 ### Install the AWS CLI
 
-Install the AWS CLI tools following the [official instructions](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html).
+Install the AWS CLI tools following the [official
+instructions](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html).
 
 ### Install Dask Cloud Provider
 
@@ -26,9 +33,13 @@ $ pip install "dask-cloudprovider[aws]"
 
 ## Cluster setup
 
-We'll now setup the [EC2Cluster](https://cloudprovider.dask.org/en/latest/aws.html#elastic-compute-cloud-ec2) from Dask Cloud Provider.
+We'll now setup the [EC2Cluster](https://cloudprovider.dask.org/en/latest/aws.html#elastic-compute-cloud-ec2) from Dask
+Cloud Provider.
 
-To do this, you'll first need to run `aws configure` and ensure the credentials are updated. [Learn more about the setup](https://cloudprovider.dask.org/en/latest/aws.html#authentication). The API also expects a security group that allows access to ports 8786-8787 and all traffic between instances in the security group. If you do not pass a group here, `dask-cloudprovider` will create one for you.
+To do this, you'll first need to run `aws configure` and ensure the credentials are updated. [Learn more about the
+setup](https://cloudprovider.dask.org/en/latest/aws.html#authentication). The API also expects a security group that
+allows access to ports 8786-8787 and all traffic between instances in the security group. If you do not pass a group
+here, `dask-cloudprovider` will create one for you.
 
 ```python
 from dask_cloudprovider.aws import EC2Cluster
@@ -48,7 +59,8 @@ cluster = EC2Cluster(
 ```
 
 ```{warning}
-Instantiating this class can take upwards of 30 minutes. See the [Dask docs](https://cloudprovider.dask.org/en/latest/packer.html) on prebuilding AMIs to speed this up.
+Instantiating this class can take upwards of 30 minutes. See the [Dask
+docs](https://cloudprovider.dask.org/en/latest/packer.html) on prebuilding AMIs to speed this up.
 ```
 
 ````{dropdown} If you have non-default credentials you may need to pass your credentials manually.
@@ -103,7 +115,8 @@ df.x.mean().compute()
 
 ## Clean up
 
-When you create your cluster Dask Cloud Provider will register a finalizer to shutdown the cluster. So when your Python process exits the cluster will be cleaned up.
+When you create your cluster Dask Cloud Provider will register a finalizer to shutdown the cluster. So when your Python
+process exits the cluster will be cleaned up.
 
 You can also explicitly shutdown the cluster with:
 

--- a/source/cloud/aws/ec2.md
+++ b/source/cloud/aws/ec2.md
@@ -6,16 +6,22 @@ review_priority: "p1"
 
 ## Create Instance
 
-Create a new [EC2 Instance](https://aws.amazon.com/ec2/) with GPUs, the [NVIDIA Driver](https://www.nvidia.co.uk/Download/index.aspx) and the [NVIDIA Container Runtime](https://developer.nvidia.com/nvidia-container-runtime).
+Create a new [EC2 Instance](https://aws.amazon.com/ec2/) with GPUs, the [NVIDIA
+Driver](https://www.nvidia.co.uk/Download/index.aspx) and the [NVIDIA Container
+Runtime](https://developer.nvidia.com/nvidia-container-runtime).
 
-NVIDIA maintains an [Amazon Machine Image (AMI) that pre-installs NVIDIA drivers and container runtimes](https://aws.amazon.com/marketplace/pp/prodview-7ikjtg3um26wq), we recommend using this image as the starting point.
+NVIDIA maintains an [Amazon Machine Image (AMI) that pre-installs NVIDIA drivers and container
+runtimes](https://aws.amazon.com/marketplace/pp/prodview-7ikjtg3um26wq), we recommend using this image as the starting
+point.
 
 1. Open the [**EC2 Dashboard**](https://console.aws.amazon.com/ec2/home).
 1. Select **Launch Instance**.
 1. In the AMI selection box search for "nvidia", then switch to the **AWS Marketplace AMIs** tab.
-1. Select **NVIDIA GPU-Optimized AMI** and click "Select". Then, in the new popup, select **Subscribe on Instance Launch**.
+1. Select **NVIDIA GPU-Optimized AMI** and click "Select". Then, in the new popup, select **Subscribe on Instance
+   Launch**.
 1. In **Key pair** select your SSH keys (create these first if you haven't already).
-1. Under network settings create a security group (or choose an existing) that allows SSH access on port `22` and also allow ports `8888,8786,8787` to access Jupyter and Dask.
+1. Under network settings create a security group (or choose an existing) that allows SSH access on port `22` and also
+   allow ports `8888,8786,8787` to access Jupyter and Dask.
 1. Select **Launch**.
 
 ## Connect to the instance
@@ -37,7 +43,8 @@ If you use the AWS Console, please use the default `ubuntu` user to ensure the N
 ```
 
 ```{note}
-If you see a "modprobe: FATAL: Module nvidia not found in directory /lib/modules/6.2.0-1011-aws" while first connecting to the EC2 instance, try logging out and reconnecting again.
+If you see a "modprobe: FATAL: Module nvidia not found in directory /lib/modules/6.2.0-1011-aws" while first connecting
+to the EC2 instance, try logging out and reconnecting again.
 ```
 
 ## Test RAPIDS

--- a/source/cloud/aws/ecs.md
+++ b/source/cloud/aws/ecs.md
@@ -1,17 +1,18 @@
 # Elastic Container Service (ECS)
 
-RAPIDS can be deployed on a multi-node ECS cluster using Dask’s dask-cloudprovider management tools. For more details, see our **[blog post on
-deploying on ECS.](https://medium.com/rapids-ai/getting-started-with-rapids-on-aws-ecs-using-dask-cloud-provider-b1adfdbc9c6e)**
+RAPIDS can be deployed on a multi-node ECS cluster using Dask’s dask-cloudprovider management tools. For more details,
+see our **[blog post on deploying on
+ECS.](https://medium.com/rapids-ai/getting-started-with-rapids-on-aws-ecs-using-dask-cloud-provider-b1adfdbc9c6e)**
 
 ## Run from within AWS
 
-The following steps assume you are running from within the same AWS VPC. One way to ensure this is to use
-[AWS EC2 Single Instance](https://docs.rapids.ai/deployment/stable/cloud/aws/ec2.html) as your development environment.
+The following steps assume you are running from within the same AWS VPC. One way to ensure this is to use [AWS EC2
+Single Instance](https://docs.rapids.ai/deployment/stable/cloud/aws/ec2.html) as your development environment.
 
 ### Setup AWS credentials
 
-First, you will need AWS credentials to interact with the AWS CLI. If someone else manages your AWS account, you will need to
-get these keys from them. <br />
+First, you will need AWS credentials to interact with the AWS CLI. If someone else manages your AWS account, you will
+need to get these keys from them.
 
 You can provide these credentials to dask-cloudprovider in a number of ways, but the easiest is to setup your
 local environment using the AWS command line tools:
@@ -40,7 +41,8 @@ For Networking, select the default VPC and all the subnets available in that VPC
 Select "Amazon EC2 instances" for the Infrastructure type and configure your settings:
 
 - Operating system: must be Linux-based architecture
-- EC2 instance type: must support RAPIDS-compatible GPUs ([see the RAPIDS docs](https://docs.rapids.ai/install#system-req))
+- EC2 instance type: must support RAPIDS-compatible GPUs ([see the RAPIDS
+  docs](https://docs.rapids.ai/install#system-req))
 - Desired capacity: number of maximum instances to launch (default maximum 5)
 - SSH Key pair
 
@@ -50,7 +52,9 @@ Review your settings then click on the "Create" button and wait for the cluster 
 
 Get the Amazon Resource Name (ARN) for the cluster you just created.
 
-Set `AWS_REGION` environment variable to your **[default region](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-regions)**, for instance `us-east-1`
+Set `AWS_REGION` environment variable to your **[default
+region](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-regions)**,
+for instance `us-east-1`
 
 ```shell
 AWS_REGION=[REGION]
@@ -71,28 +75,31 @@ cluster = ECSCluster(
 ```
 
 ````{note}
-When you call this command for the first time, `ECSCluster()` will automatically create a **security group** with the same name as the ECS cluster you created above..
+When you call this command for the first time, `ECSCluster()` will automatically create a **security group** with the
+same name as the ECS cluster you created above..
 
-However, if the Dask cluster creation fails or you'd like to reuse the same ECS cluster for subsequent runs of `ECSCluster()`, then you will need to provide this security group value.
+However, if the Dask cluster creation fails or you'd like to reuse the same ECS cluster for subsequent runs of
+`ECSCluster()`, then you will need to provide this security group value.
 
 ```shell
 security_groups=["sg-0fde781be42651"]
 
 ````
 
-[**cluster_arn**] = ARN of an existing ECS cluster to use for launching tasks <br />
+[**cluster_arn**] = ARN of an existing ECS cluster to use for launching tasks.
 
-[**num_workers**] = number of workers to start on cluster creation <br />
+[**num_workers**] = number of workers to start on cluster creation.
 
-[**num_gpus**] = number of GPUs to expose to the worker, this must be less than or equal to the number of GPUs in the instance type you selected for the ECS cluster (e.g `1` for `p3.2xlarge`).<br />
+[**num_gpus**] = number of GPUs to expose to the worker, this must be less than or equal to the number of GPUs in the
+instance type you selected for the ECS cluster (e.g `1` for `p3.2xlarge`).
 
-[**skip_cleanup**] = if True, Dask workers won't be automatically terminated when cluster is shut down <br />
+[**skip_cleanup**] = if True, Dask workers won't be automatically terminated when cluster is shut down.
 
-[**execution_role_arn**] = ARN of the IAM role that allows the Dask cluster to create and manage ECS resources <br />
+[**execution_role_arn**] = ARN of the IAM role that allows the Dask cluster to create and manage ECS resources.
 
-[**task_role_arn**] = ARN of the IAM role that the Dask workers assume when they run <br />
+[**task_role_arn**] = ARN of the IAM role that the Dask workers assume when they run.
 
-[**scheduler_timeout**] = maximum time scheduler will wait for workers to connect to the cluster
+[**scheduler_timeout**] = maximum time scheduler will wait for workers to connect to the cluster.
 
 ## Test RAPIDS
 
@@ -126,7 +133,8 @@ Name: id, dtype: int64
 
 ## Cleanup
 
-You can scale down or delete the Dask cluster, but the ECS cluster will continue to run (and incur charges!) until you also scale it down or shut down altogether. <br />
+You can scale down or delete the Dask cluster, but the ECS cluster will continue to run (and incur charges!) until you
+also scale it down or shut down altogether.
 
 If you are planning to use the ECS cluster again soon, it is probably preferable to reduce the nodes to zero.
 

--- a/source/cloud/aws/eks.md
+++ b/source/cloud/aws/eks.md
@@ -10,7 +10,10 @@ To run RAPIDS you'll need a Kubernetes cluster with GPUs available.
 
 ## Prerequisites
 
-First you'll need to have the [`aws` CLI tool](https://aws.amazon.com/cli/) and [`eksctl` CLI tool](https://docs.aws.amazon.com/eks/latest/userguide/eksctl.html) installed along with [`kubectl`](https://kubernetes.io/docs/tasks/tools/), [`helm`](https://helm.sh/docs/intro/install/), for managing Kubernetes.
+First you'll need to have the [`aws` CLI tool](https://aws.amazon.com/cli/) and [`eksctl` CLI
+tool](https://docs.aws.amazon.com/eks/latest/userguide/eksctl.html) installed along with
+[`kubectl`](https://kubernetes.io/docs/tasks/tools/), [`helm`](https://helm.sh/docs/intro/install/), for managing
+Kubernetes.
 
 Ensure you are logged into the `aws` CLI.
 
@@ -43,7 +46,9 @@ $ eksctl create cluster rapids \
                       --auto-kubeconfig
 ```
 
-With this command, you’ve launched an EKS cluster called `rapids`. You’ve specified that it should use nodes of type `p3.8xlarge`. We also specified that we don't want to install the NVIDIA drivers as we will do that with the NVIDIA operator.
+With this command, you’ve launched an EKS cluster called `rapids`. You’ve specified that it should use nodes of type
+`p3.8xlarge`. We also specified that we don't want to install the NVIDIA drivers as we will do that with the NVIDIA
+operator.
 
 To access the cluster we need to pull down the credentials.
 Add `--profile <your-profile>` if you are not using the default profile.
@@ -54,7 +59,8 @@ $ aws eks --region us-east-1 update-kubeconfig --name rapids
 
 ## Install drivers
 
-As we selected a GPU node type EKS will automatically install drivers for us. We can verify this by listing the NVIDIA driver plugin Pods.
+As we selected a GPU node type EKS will automatically install drivers for us. We can verify this by listing the NVIDIA
+driver plugin Pods.
 
 ```console
 $ kubectl get po -n kube-system -l name=nvidia-device-plugin-ds
@@ -65,7 +71,10 @@ nvidia-device-plugin-daemonset-thjhc   1/1     Running   0          52m
 ```
 
 ```{note}
-By default this plugin will install the latest version on the NVIDIA drivers on every Node. If you need more control over your driver installation we recommend that when creating your cluster you set `eksctl create cluster --install-nvidia-plugin=false ...` and then install drivers yourself using the [NVIDIA GPU Operator](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/getting-started.html).
+By default this plugin will install the latest version on the NVIDIA drivers on every Node. If you need more control
+over your driver installation we recommend that when creating your cluster you set
+`eksctl create cluster --install-nvidia-plugin=false ...` and then install drivers yourself using the [NVIDIA GPU
+Operator](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/getting-started.html).
 ```
 
 After you have confirmed your drivers are installed, you are ready to test your cluster.
@@ -76,7 +85,8 @@ After you have confirmed your drivers are installed, you are ready to test your 
 
 ## Install RAPIDS
 
-Now that you have a GPU enabled Kubernetes cluster on EKS you can install RAPIDS with [any of the supported methods](../../platforms/kubernetes).
+Now that you have a GPU enabled Kubernetes cluster on EKS you can install RAPIDS with [any of the supported
+methods](../../platforms/kubernetes).
 
 ## Clean up
 

--- a/source/cloud/aws/sagemaker.md
+++ b/source/cloud/aws/sagemaker.md
@@ -8,7 +8,8 @@ RAPIDS can be used in a few ways with [AWS SageMaker](https://aws.amazon.com/sag
 
 ## SageMaker Notebooks
 
-To get started head to [the SageMaker console](https://console.aws.amazon.com/sagemaker/) and create a [new SageMaker Notebook Instance](https://console.aws.amazon.com/sagemaker/home#/notebook-instances/create).
+To get started head to [the SageMaker console](https://console.aws.amazon.com/sagemaker/) and create a [new SageMaker
+Notebook Instance](https://console.aws.amazon.com/sagemaker/home#/notebook-instances/create).
 
 Choose `Applications and IDEs > Notebooks > Create notebook instance`.
 
@@ -17,16 +18,21 @@ Choose `Applications and IDEs > Notebooks > Create notebook instance`.
 If a field is not mentioned below, leave the default values:
 
 - **Notebook instance name** = Name of the notebook instance
-- **Notebook instance type** = Type of notebook instance. Select a RAPIDS-compatible GPU ([see the RAPIDS docs](https://docs.rapids.ai/install#system-req)) as the SageMaker Notebook instance type (e.g., `ml.p3.2xlarge`).
+- **Notebook instance type** = Type of notebook instance. Select a RAPIDS-compatible GPU ([see the RAPIDS
+  docs](https://docs.rapids.ai/install#system-req)) as the SageMaker Notebook instance type (e.g., `ml.p3.2xlarge`).
 - **Platform identifier** = 'Amazon Linux 2, Jupyter Lab 4'
 
-![Screenshot of the create new notebook screen with a ml.p3.2xlarge selected](../../images/sagemaker-create-notebook-instance.png)
+![Screenshot of the create new notebook screen with a ml.p3.2xlarge
+selected](../../images/sagemaker-create-notebook-instance.png)
 
 ### Create a RAPIDS lifecycle configuration
 
-[SageMaker Notebook Instances](https://docs.aws.amazon.com/sagemaker/latest/dg/nbi.html) can be augmented with a RAPIDS conda environment.
+[SageMaker Notebook Instances](https://docs.aws.amazon.com/sagemaker/latest/dg/nbi.html) can be augmented with a RAPIDS
+conda environment.
 
-We can add a RAPIDS conda environment to the set of Jupyter ipython kernels available in our SageMaker notebook instance by installing in a [lifecycle configuration script](https://docs.aws.amazon.com/sagemaker/latest/dg/notebook-lifecycle-config.html).
+We can add a RAPIDS conda environment to the set of Jupyter ipython kernels available in our SageMaker notebook instance
+by installing in a [lifecycle configuration
+script](https://docs.aws.amazon.com/sagemaker/latest/dg/notebook-lifecycle-config.html).
 
 Create a new lifecycle configuration (via the 'Additional Configuration' dropdown).
 
@@ -68,7 +74,8 @@ Then launch the instance.
 Once your Notebook Instance is `InService` select "Open JupyterLab"
 
 ```{note}
-If you see Pending to the right of the notebook instance in the Status column, your notebook is still being created. The status will change to InService when the notebook is ready for use.
+If you see Pending to the right of the notebook instance in the Status column, your notebook is still being created. The
+status will change to InService when the notebook is ready for use.
 ```
 
 Then in Jupyter select the `rapids` kernel when working with a new notebook.
@@ -77,25 +84,33 @@ Then in Jupyter select the `rapids` kernel when working with a new notebook.
 
 ### Run the Example Notebook
 
-Once inside JupyterLab you should be able to upload the [Running RAPIDS hyperparameter experiments at scale](/examples/rapids-sagemaker-higgs/notebook) example notebook and continue following those instructions.
+Once inside JupyterLab you should be able to upload the [Running RAPIDS hyperparameter experiments at
+scale](/examples/rapids-sagemaker-higgs/notebook) example notebook and continue following those instructions.
 
 ## SageMaker Estimators
 
-RAPIDS can also be used in [SageMaker Estimators](https://sagemaker.readthedocs.io/en/stable/api/training/estimators.html).
-Estimators allow you to launch training jobs on ephemeral VMs which SageMaker manages for you.
-With this option, your Notebook Instance doesn't need to have a GPU... you are only charged for GPU instances for the time that your training job is running.
+RAPIDS can also be used in [SageMaker
+Estimators](https://sagemaker.readthedocs.io/en/stable/api/training/estimators.html). Estimators allow you to launch
+training jobs on ephemeral VMs which SageMaker manages for you. With this option, your Notebook Instance doesn't need to
+have a GPU... you are only charged for GPU instances for the time that your training job is running.
 
-All you’ll need to do is bring in your RAPIDS training script and libraries as a Docker container image and ask Amazon SageMaker to run copies of it in parallel on a specified number of GPU instances.
+All you’ll need to do is bring in your RAPIDS training script and libraries as a Docker container image and ask Amazon
+SageMaker to run copies of it in parallel on a specified number of GPU instances.
 
 Let’s take a closer look at how this works through a step-by-step approach:
 
-- Training script should accept hyperparameters as command line arguments. Starting with the base RAPIDS container (pulled from [Docker Hub](https://hub.docker.com/u/rapidsai)), use a `Dockerfile` to augment it by copying your training code and set `WORKDIR` path to the code.
+- Training script should accept hyperparameters as command line arguments. Starting with the base RAPIDS container
+  (pulled from [Docker Hub](https://hub.docker.com/u/rapidsai)), use a `Dockerfile` to augment it by copying your
+  training code and set `WORKDIR` path to the code.
 
-- Install [sagemaker-training toolkit](https://github.com/aws/sagemaker-training-toolkit) to make the container compatible with Sagemaker. Add other packages as needed for your workflow needs e.g. python, flask (model serving), dask-ml etc.
+- Install [sagemaker-training toolkit](https://github.com/aws/sagemaker-training-toolkit) to make the container
+  compatible with Sagemaker. Add other packages as needed for your workflow needs e.g. python, flask (model serving),
+  dask-ml etc.
 
 - Push the image to a container registry (ECR).
 
-- Having built our container and custom logic, we can now assemble all components into an Estimator. We can now test the Estimator and run parallel hyperparameter optimization tuning jobs.
+- Having built our container and custom logic, we can now assemble all components into an Estimator. We can now test the
+  Estimator and run parallel hyperparameter optimization tuning jobs.
 
 Estimators follow an API roughly like this:
 
@@ -132,11 +147,14 @@ hpo = sagemaker.tuner.HyperparameterTuner(
 hpo.fit(inputs=s3_data_input, job_name=tuning_job_name, wait=True, logs="All")
 ```
 
-For a hands-on demo of this, try ["Deep Dive into running Hyper Parameter Optimization on AWS SageMaker"]/examples/rapids-sagemaker-higgs/notebook).
+For a hands-on demo of this, try ["Deep Dive into running Hyper Parameter Optimization on AWS
+SageMaker"]/examples/rapids-sagemaker-higgs/notebook).
 
 ## Further reading
 
-We’ve also written a **[detailed blog post](https://medium.com/rapids-ai/running-rapids-experiments-at-scale-using-amazon-sagemaker-d516420f165b)** on how to use SageMaker with RAPIDS.
+We’ve also written a **[detailed blog
+post](https://medium.com/rapids-ai/running-rapids-experiments-at-scale-using-amazon-sagemaker-d516420f165b)** on how to
+use SageMaker with RAPIDS.
 
 ```{relatedexamples}
 

--- a/source/cloud/azure/aks.md
+++ b/source/cloud/azure/aks.md
@@ -4,13 +4,16 @@ review_priority: "p1"
 
 # Azure Kubernetes Service
 
-RAPIDS can be deployed on Azure via the [Azure Kubernetes Service](https://azure.microsoft.com/en-us/products/kubernetes-service/) (AKS).
+RAPIDS can be deployed on Azure via the [Azure Kubernetes
+Service](https://azure.microsoft.com/en-us/products/kubernetes-service/) (AKS).
 
 To run RAPIDS you'll need a Kubernetes cluster with GPUs available.
 
 ## Prerequisites
 
-First you'll need to have the [`az` CLI tool](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli) installed along with [`kubectl`](https://kubernetes.io/docs/tasks/tools/), [`helm`](https://helm.sh/docs/intro/install/), etc for managing Kubernetes.
+First you'll need to have the [`az` CLI tool](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli) installed
+along with [`kubectl`](https://kubernetes.io/docs/tasks/tools/), [`helm`](https://helm.sh/docs/intro/install/), etc for
+managing Kubernetes.
 
 Ensure you are logged into the `az` CLI.
 
@@ -38,7 +41,8 @@ $ az aks get-credentials -g <resource group> --name rapids
 Merged "rapids" as current context in ~/.kube/config
 ```
 
-Next we need to add an additional node group with GPUs which you can [learn more about in the Azure docs](https://learn.microsoft.com/en-us/azure/aks/gpu-cluster).
+Next we need to add an additional node group with GPUs which you can [learn more about in the Azure
+docs](https://learn.microsoft.com/en-us/azure/aks/gpu-cluster).
 
 `````{note}
 You will need the `GPUDedicatedVHDPreview` feature enabled so that NVIDIA drivers are installed automatically.
@@ -60,7 +64,8 @@ If it is not registered for you you'll need to register it which can take a few 
 
 ```console
 $ az feature register --name GPUDedicatedVHDPreview --namespace Microsoft.ContainerService
-Once the feature 'GPUDedicatedVHDPreview' is registered, invoking 'az provider register -n Microsoft.ContainerService' is required to get the change propagated
+Once the feature 'GPUDedicatedVHDPreview' is registered, invoking 'az provider register -n Microsoft.ContainerService'
+is required to get the change propagated
 Name
 -------------------------------------------------
 Microsoft.ContainerService/GPUDedicatedVHDPreview
@@ -75,7 +80,8 @@ Name                                               State
 Microsoft.ContainerService/GPUDedicatedVHDPreview  Registered
 ```
 
-When the status shows as registered, refresh the registration of the `Microsoft.ContainerService` resource provider by using the `az provider register` command:
+When the status shows as registered, refresh the registration of the `Microsoft.ContainerService` resource provider by
+using the `az provider register` command:
 
 ```console
 $ az provider register --namespace Microsoft.ContainerService
@@ -103,7 +109,8 @@ az aks nodepool add \
     --max-count 3
 ```
 
-Here we have added a new pool made up of `Standard_NC48ads_A100_v4` instances which each have two A100 GPUs. We've also enabled autoscaling between one and three nodes on the pool.
+Here we have added a new pool made up of `Standard_NC48ads_A100_v4` instances which each have two A100 GPUs. We've also
+enabled autoscaling between one and three nodes on the pool.
 
 Then we can install the NVIDIA drivers.
 
@@ -124,7 +131,8 @@ we should be able to test that we can schedule GPU pods.
 
 ## Install RAPIDS
 
-Now that you have a GPU enables Kubernetes cluster on AKS you can install RAPIDS with [any of the supported methods](../../platforms/kubernetes).
+Now that you have a GPU enables Kubernetes cluster on AKS you can install RAPIDS with [any of the supported
+methods](../../platforms/kubernetes).
 
 ## Clean up
 

--- a/source/cloud/azure/azure-vm-multi.md
+++ b/source/cloud/azure/azure-vm-multi.md
@@ -2,11 +2,13 @@
 
 ## Create a Cluster using Dask Cloud Provider
 
-The easiest way to setup a multi-node, multi-GPU cluster on Azure is to use [Dask Cloud Provider](https://cloudprovider.dask.org/en/latest/azure.html).
+The easiest way to setup a multi-node, multi-GPU cluster on Azure is to use [Dask Cloud
+Provider](https://cloudprovider.dask.org/en/latest/azure.html).
 
 ### 1. Install Dask Cloud Provider
 
-Dask Cloud Provider can be installed via `conda` or `pip`. The Azure-specific capabilities will need to be installed via the `[azure]` pip extra.
+Dask Cloud Provider can be installed via `conda` or `pip`. The Azure-specific capabilities will need to be installed via
+the `[azure]` pip extra.
 
 ```shell
 $ pip install dask-cloudprovider[azure]
@@ -14,11 +16,16 @@ $ pip install dask-cloudprovider[azure]
 
 ### 2. Configure your Azure Resources
 
-Set up your [Azure Resource Group](https://cloudprovider.dask.org/en/latest/azure.html#resource-groups), [Virtual Network](https://cloudprovider.dask.org/en/latest/azure.html#virtual-networks), and [Security Group](https://cloudprovider.dask.org/en/latest/azure.html#security-groups) according to [Dask Cloud Provider instructions](https://cloudprovider.dask.org/en/latest/azure.html#authentication).
+Set up your [Azure Resource Group](https://cloudprovider.dask.org/en/latest/azure.html#resource-groups), [Virtual
+Network](https://cloudprovider.dask.org/en/latest/azure.html#virtual-networks), and [Security
+Group](https://cloudprovider.dask.org/en/latest/azure.html#security-groups) according to [Dask Cloud Provider
+instructions](https://cloudprovider.dask.org/en/latest/azure.html#authentication).
 
 ### 3. Create a Cluster
 
-In Python terminal, a cluster can be created using the `dask_cloudprovider` package. The below example creates a cluster with 2 workers in `westus2` with `Standard_NC12s_v3` VMs. The VMs should have at least 100GB of disk space in order to accommodate the RAPIDS container image and related dependencies.
+In Python terminal, a cluster can be created using the `dask_cloudprovider` package. The below example creates a cluster
+with 2 workers in `westus2` with `Standard_NC12s_v3` VMs. The VMs should have at least 100GB of disk space in order to
+accommodate the RAPIDS container image and related dependencies.
 
 ```python
 from dask_cloudprovider.azure import AzureVMCluster

--- a/source/cloud/azure/azure-vm.md
+++ b/source/cloud/azure/azure-vm.md
@@ -6,9 +6,13 @@ review_priority: "p1"
 
 ## Create Virtual Machine
 
-Create a new [Azure Virtual Machine](https://azure.microsoft.com/en-gb/products/virtual-machines/) with GPUs, the [NVIDIA Driver](https://www.nvidia.co.uk/Download/index.aspx) and the [NVIDIA Container Runtime](https://developer.nvidia.com/nvidia-container-runtime).
+Create a new [Azure Virtual Machine](https://azure.microsoft.com/en-gb/products/virtual-machines/) with GPUs, the
+[NVIDIA Driver](https://www.nvidia.co.uk/Download/index.aspx) and the [NVIDIA Container
+Runtime](https://developer.nvidia.com/nvidia-container-runtime).
 
-NVIDIA maintains a [Virtual Machine Image (VMI) that pre-installs NVIDIA drivers and container runtimes](https://azuremarketplace.microsoft.com/en-us/marketplace/apps/nvidia.ngc_azure_17_11?tab=Overview), we recommend using this image as the starting point.
+NVIDIA maintains a [Virtual Machine Image (VMI) that pre-installs NVIDIA drivers and container
+runtimes](https://azuremarketplace.microsoft.com/en-us/marketplace/apps/nvidia.ngc_azure_17_11?tab=Overview), we
+recommend using this image as the starting point.
 
 `````{tab-set}
 
@@ -16,7 +20,8 @@ NVIDIA maintains a [Virtual Machine Image (VMI) that pre-installs NVIDIA drivers
 :sync: portal
 
 1. Select a resource group or create one if needed.
-2. Select the latest **NVIDIA GPU-Optimized VMI** version from the drop down list, then select **Get It Now** (if there are multiple `Gen` versions, select the latest).
+2. Select the latest **NVIDIA GPU-Optimized VMI** version from the drop down list, then select **Get It Now** (if there
+are multiple `Gen` versions, select the latest).
 3. If already logged in on Azure, select continue clicking **Create**.
 4. In **Create a virtual machine** interface, fill in required information for the vm.
    - Select a GPU enabled VM size (see [recommended VM types](https://docs.rapids.ai/deployment/stable/cloud/azure/)).
@@ -123,7 +128,8 @@ az network nsg rule create \
 
 ## Install RAPIDS
 
-Next, we can SSH into our VM to install RAPIDS. SSH instructions can be found by selecting **Connect** in the left panel.
+Next, we can SSH into our VM to install RAPIDS. SSH instructions can be found by selecting **Connect** in the left
+panel.
 
 ````{tip}
 When connecting via SSH by doing

--- a/source/cloud/azure/azureml.md
+++ b/source/cloud/azure/azureml.md
@@ -4,11 +4,20 @@ review_priority: "p0"
 
 # Azure Machine Learning
 
-RAPIDS can be deployed at scale using [Azure Machine Learning Service](https://learn.microsoft.com/en-us/azure/machine-learning/overview-what-is-azure-machine-learning) and can be scaled up to any size needed.
+RAPIDS can be deployed at scale using [Azure Machine Learning
+Service](https://learn.microsoft.com/en-us/azure/machine-learning/overview-what-is-azure-machine-learning) and can be
+scaled up to any size needed.
 
 ## Pre-requisites
 
-Use existing or create new Azure Machine Learning workspace through the [Azure portal](https://learn.microsoft.com/en-us/azure/machine-learning/how-to-manage-workspace?tabs=azure-portal#create-a-workspace), [Azure ML Python SDK](https://learn.microsoft.com/en-us/azure/machine-learning/how-to-manage-workspace?tabs=python#create-a-workspace), [Azure CLI](https://learn.microsoft.com/en-us/azure/machine-learning/how-to-manage-workspace-cli?tabs=createnewresources) or [Azure Resource Manager templates](https://learn.microsoft.com/en-us/azure/machine-learning/how-to-create-workspace-template?tabs=azcli).
+Use existing or create new Azure Machine Learning workspace through the [Azure
+portal](https://learn.microsoft.com/en-us/azure/machine-learning/how-to-manage-workspace?tabs=azure-portal#create-a-workspace),
+[Azure ML Python
+SDK](https://learn.microsoft.com/en-us/azure/machine-learning/how-to-manage-workspace?tabs=python#create-a-workspace),
+[Azure
+CLI](https://learn.microsoft.com/en-us/azure/machine-learning/how-to-manage-workspace-cli?tabs=createnewresources) or
+[Azure Resource Manager
+templates](https://learn.microsoft.com/en-us/azure/machine-learning/how-to-create-workspace-template?tabs=azcli).
 
 Follow these high-level steps to get started:
 
@@ -16,19 +25,26 @@ Follow these high-level steps to get started:
 
 **2. Workspace.** Within the Resource Group, create an Azure Machine Learning service Workspace.
 
-**3. Quota.** Check your subscription Usage + Quota to ensure you have enough quota within your region to launch your desired compute instance.
+**3. Quota.** Check your subscription Usage + Quota to ensure you have enough quota within your region to launch your
+desired compute instance.
 
 ## Azure ML Compute instance
 
-Although it is possible to install Azure Machine Learning on your local computer, it is recommended to utilize [Azure's ML Compute instances](https://learn.microsoft.com/en-us/azure/machine-learning/concept-compute-instance), fully managed and secure development environments that can also serve as a [compute target](https://learn.microsoft.com/en-us/azure/machine-learning/concept-compute-target?view=azureml-api-2) for ML training.
+Although it is possible to install Azure Machine Learning on your local computer, it is recommended to utilize [Azure's
+ML Compute instances](https://learn.microsoft.com/en-us/azure/machine-learning/concept-compute-instance), fully managed
+and secure development environments that can also serve as a [compute
+target](https://learn.microsoft.com/en-us/azure/machine-learning/concept-compute-target?view=azureml-api-2) for ML
+training.
 
-The compute instance provides an integrated Jupyter notebook service, JupyterLab, Azure ML Python SDK, CLI, and other essential tools.
+The compute instance provides an integrated Jupyter notebook service, JupyterLab, Azure ML Python SDK, CLI, and other
+essential tools.
 
 ### Select your instance
 
 Sign in to [Azure Machine Learning Studio](https://ml.azure.com/) and navigate to your workspace on the left-side menu.
 
-Select **New** > **Compute instance** (Create compute instance) > choose an [Azure RAPIDS compatible GPU](https://docs.rapids.ai/deployment/stable/cloud/azure/) VM size (e.g., `Standard_NC12s_v3`)
+Select **New** > **Compute instance** (Create compute instance) > choose an [Azure RAPIDS compatible
+GPU](https://docs.rapids.ai/deployment/stable/cloud/azure/) VM size (e.g., `Standard_NC12s_v3`)
 
 ![Screenshot of create new notebook with a gpu-instance](../../images/azureml-create-notebook-instance.png)
 
@@ -62,19 +78,25 @@ Select `local file`, then `Browse`, and upload that script.
 
 ![Screenshot of the provision setup script screen](../../images/azureml-provision-setup-script.png)
 
-Refer to [Azure ML documentation](https://learn.microsoft.com/en-us/azure/machine-learning/how-to-customize-compute-instance) for more details on how to create the setup script.
+Refer to [Azure ML
+documentation](https://learn.microsoft.com/en-us/azure/machine-learning/how-to-customize-compute-instance) for more
+details on how to create the setup script.
 
 Launch the instance.
 
 ### Select the RAPIDS environment
 
-Once your Notebook Instance is `Running`, open "JupyterLab" and select the `rapids` kernel when working with a new notebook.
+Once your Notebook Instance is `Running`, open "JupyterLab" and select the `rapids` kernel when working with a new
+notebook.
 
 ## Azure ML Compute cluster
 
-In the next section we will launch Azure's [ML Compute cluster](https://learn.microsoft.com/en-us/azure/machine-learning/how-to-create-attach-compute-cluster?tabs=python) to distribute your RAPIDS training jobs across a cluster of single or multi-GPU compute nodes.
+In the next section we will launch Azure's [ML Compute
+cluster](https://learn.microsoft.com/en-us/azure/machine-learning/how-to-create-attach-compute-cluster?tabs=python) to
+distribute your RAPIDS training jobs across a cluster of single or multi-GPU compute nodes.
 
-The Compute cluster scales up automatically when a job is submitted, and executes in a containerized environment, packaging your model dependencies in a Docker container.
+The Compute cluster scales up automatically when a job is submitted, and executes in a containerized environment,
+packaging your model dependencies in a Docker container.
 
 ### Instantiate workspace
 
@@ -99,13 +121,19 @@ ml_client = MLClient.from_config(
 
 ### Create AMLCompute
 
-You will need to create a [compute target](https://learn.microsoft.com/en-us/azure/machine-learning/concept-compute-target?view=azureml-api-2#azure-machine-learning-compute-managed) using Azure ML managed compute ([AmlCompute](https://azuresdkdocs.blob.core.windows.net/$web/python/azure-ai-ml/0.1.0b4/azure.ai.ml.entities.html)) for remote training.
+You will need to create a [compute
+target](https://learn.microsoft.com/en-us/azure/machine-learning/concept-compute-target?view=azureml-api-2#azure-machine-learning-compute-managed)
+using Azure ML managed compute
+([AmlCompute](https://azuresdkdocs.blob.core.windows.net/$web/python/azure-ai-ml/0.1.0b4/azure.ai.ml.entities.html)) for
+remote training.
 
 ```{note}
 Be sure to check instance availability and its limits within the region where you created your compute instance.
 ```
 
-This [article](https://learn.microsoft.com/en-us/azure/machine-learning/how-to-manage-quotas?view=azureml-api-2#azure-machine-learning-compute) includes details on the default limits and how to request more quota.
+This
+[article](https://learn.microsoft.com/en-us/azure/machine-learning/how-to-manage-quotas?view=azureml-api-2#azure-machine-learning-compute)
+includes details on the default limits and how to request more quota.
 
 [**size**]: The VM family of the nodes.
 Specify from one of **NC_v2**, **NC_v3**, **ND** or **ND_v2** GPU virtual machines (e.g `Standard_NC12s_v3`)
@@ -113,7 +141,9 @@ Specify from one of **NC_v2**, **NC_v3**, **ND** or **ND_v2** GPU virtual machin
 [**max_instances**]: The max number of nodes to autoscale up to when you run a job
 
 ```{note}
-You may choose to use low-priority VMs to run your workloads. These VMs don't have guaranteed availability but allow you to take advantage of Azure's unused capacity at a significant cost savings. The amount of available capacity can vary based on size, region, time of day, and more.
+You may choose to use low-priority VMs to run your workloads. These VMs don't have guaranteed availability but allow you
+to take advantage of Azure's unused capacity at a significant cost savings. The amount of available capacity can vary
+based on size, region, time of day, and more.
 ```
 
 ```python
@@ -130,12 +160,16 @@ gpu_compute = AmlCompute(
 ml_client.begin_create_or_update(gpu_compute).result()
 ```
 
-If you name your cluster `"rapids-cluster"` you can check [https://ml.azure.com/compute/rapids-cluster/details](https://ml.azure.com/compute/rapids-cluster/details)
-to see the details about your cluster.
+If you name your cluster `"rapids-cluster"` you can check
+[https://ml.azure.com/compute/rapids-cluster/details](https://ml.azure.com/compute/rapids-cluster/details) to see the
+details about your cluster.
 
 ### Access Datastore URI
 
-A [datastore URI](https://learn.microsoft.com/en-us/azure/machine-learning/how-to-access-data-interactive?tabs=adls&view=azureml-api-2#access-data-from-a-datastore-uri-like-a-filesystem-preview) is a reference to a blob storage location (path) on your Azure account. You can copy-and-paste the datastore URI from the AzureML Studio UI:
+A [datastore
+URI](https://learn.microsoft.com/en-us/azure/machine-learning/how-to-access-data-interactive?tabs=adls&view=azureml-api-2#access-data-from-a-datastore-uri-like-a-filesystem-preview)
+is a reference to a blob storage location (path) on your Azure account. You can copy-and-paste the datastore URI from
+the AzureML Studio UI:
 
 1. Select **Data** from the left-hand menu > **Datastores** > choose your datastore name > **Browse**
 2. Find the file/folder containing your dataset and click the ellipsis (...) next to it.
@@ -145,12 +179,20 @@ A [datastore URI](https://learn.microsoft.com/en-us/azure/machine-learning/how-t
 
 ### Custom RAPIDS Environment
 
-To run an AzureML experiment, you must specify an [environment](https://learn.microsoft.com/en-us/azure/machine-learning/concept-environments?view=azureml-api-2) that contains all the necessary software dependencies to run the training script on distributed nodes. <br>
-You can define an environment from a [pre-built](https://learn.microsoft.com/en-us/azure/machine-learning/how-to-manage-environments-v2?tabs=python&view=azureml-api-2#create-an-environment-from-a-docker-image) docker image or create-your-own from a [Dockerfile](https://learn.microsoft.com/en-us/azure/machine-learning/how-to-manage-environments-v2?tabs=python&view=azureml-api-2#create-an-environment-from-a-docker-build-context) or [conda](https://learn.microsoft.com/en-us/azure/machine-learning/how-to-manage-environments-v2?tabs=python&view=azureml-api-2#create-an-environment-from-a-conda-specification) specification file.
+To run an AzureML experiment, you must specify an
+[environment](https://learn.microsoft.com/en-us/azure/machine-learning/concept-environments?view=azureml-api-2) that
+contains all the necessary software dependencies to run the training script on distributed nodes.
 
-In a notebook cell, run the following to copy the example code from this documentation into a new folder,
-and to create a Dockerfile to build and image that starts from a RAPIDS image and install additional packages needed for the
-workflow.
+You can define an environment from a
+[pre-built](https://learn.microsoft.com/en-us/azure/machine-learning/how-to-manage-environments-v2?tabs=python&view=azureml-api-2#create-an-environment-from-a-docker-image)
+docker image or create-your-own from a
+[Dockerfile](https://learn.microsoft.com/en-us/azure/machine-learning/how-to-manage-environments-v2?tabs=python&view=azureml-api-2#create-an-environment-from-a-docker-build-context)
+or
+[conda](https://learn.microsoft.com/en-us/azure/machine-learning/how-to-manage-environments-v2?tabs=python&view=azureml-api-2#create-an-environment-from-a-conda-specification)
+specification file.
+
+In a notebook cell, run the following to copy the example code from this documentation into a new folder, and to create
+a Dockerfile to build and image that starts from a RAPIDS image and install additional packages needed for the workflow.
 
 ```ipython
 %%bash
@@ -188,7 +230,9 @@ ml_client.environments.create_or_update(env_docker_image)
 
 ### Submit RAPIDS Training jobs
 
-Now that we have our environment and custom logic, we can configure and run the `command` [class](https://learn.microsoft.com/en-us/python/api/azure-ai-ml/azure.ai.ml?view=azure-python#azure-ai-ml-command) to submit training jobs.
+Now that we have our environment and custom logic, we can configure and run the `command`
+[class](https://learn.microsoft.com/en-us/python/api/azure-ai-ml/azure.ai.ml?view=azure-python#azure-ai-ml-command) to
+submit training jobs.
 
 `inputs` is a dictionary of command-line arguments to pass to the training script.
 
@@ -266,9 +310,9 @@ returned_sweep_job = ml_client.create_or_update(sweep_job)
 returned_sweep_job
 ```
 
-Once the job is created, click on the details page provided in the output of `returned_sweep_job`, or go
-to [the "Experiments" page](https://ml.azure.com/experiments) to view logs, metrics, and outputs. The three trials
-set in the `sweep_job.set_limits(...)` take between 20-40 min to complete when using `size="Standard_NC6s_v3"`.
+Once the job is created, click on the details page provided in the output of `returned_sweep_job`, or go to [the
+"Experiments" page](https://ml.azure.com/experiments) to view logs, metrics, and outputs. The three trials set in the
+`sweep_job.set_limits(...)` take between 20-40 min to complete when using `size="Standard_NC6s_v3"`.
 
 ### Clean Up
 
@@ -278,8 +322,8 @@ When you're done, remove the compute resources.
 ml_client.compute.begin_delete(gpu_compute.name).wait()
 ```
 
-Then check [https://ml.azure.com/compute/list/instances](https://ml.azure.com/compute/list/instances) and make sure your compute instance
-is also stopped, and deleted if desired.
+Then check [https://ml.azure.com/compute/list/instances](https://ml.azure.com/compute/list/instances) and make sure your
+compute instance is also stopped, and deleted if desired.
 
 ```{relatedexamples}
 

--- a/source/cloud/gcp/compute-engine.md
+++ b/source/cloud/gcp/compute-engine.md
@@ -6,16 +6,21 @@ review_priority: "p1"
 
 ## Create Virtual Machine
 
-Create a new [Compute Engine Instance](https://cloud.google.com/compute/docs/instances) with GPUs, the [NVIDIA Driver](https://www.nvidia.co.uk/Download/index.aspx) and the [NVIDIA Container Runtime](https://developer.nvidia.com/nvidia-container-runtime).
+Create a new [Compute Engine Instance](https://cloud.google.com/compute/docs/instances) with GPUs, the [NVIDIA
+Driver](https://www.nvidia.co.uk/Download/index.aspx) and the [NVIDIA Container
+Runtime](https://developer.nvidia.com/nvidia-container-runtime).
 
-NVIDIA maintains a [Virtual Machine Image (VMI) that pre-installs NVIDIA drivers and container runtimes](https://console.cloud.google.com/marketplace/product/nvidia-ngc-public/nvidia-gpu-optimized-vmi), we recommend using this image.
+NVIDIA maintains a [Virtual Machine Image (VMI) that pre-installs NVIDIA drivers and container
+runtimes](https://console.cloud.google.com/marketplace/product/nvidia-ngc-public/nvidia-gpu-optimized-vmi), we recommend
+using this image.
 
 1. Open [**Compute Engine**](https://console.cloud.google.com/compute/instances).
 1. Select **Create Instance**.
 1. Select the **Create VM from..** option at the top.
 1. Select **Marketplace**.
 1. Search for "nvidia" and select **NVIDIA GPU-Optimized VMI**, then select **Launch**.
-1. In the **New NVIDIA GPU-Optimized VMI deployment** interface, fill in the name and any required information for the vm (the defaults should be fine for most users).
+1. In the **New NVIDIA GPU-Optimized VMI deployment** interface, fill in the name and any required information for the
+   vm (the defaults should be fine for most users).
 1. **Read and accept** the Terms of Service
 1. Select **Deploy** to start the virtual machine.
 
@@ -29,7 +34,8 @@ To access Jupyter and Dask we will need to set up some firewall rules to open up
 2. Select **Firewall** and **Create firewall rule**
 3. Give the rule a name like `rapids` and ensure the network matches the one you selected for the VM.
 4. Add a tag like `rapids` which we will use to assign the rule to our VM.
-5. Set your source IP range. We recommend you restrict this to your own IP address or your corporate network rather than `0.0.0.0/0` which will allow anyone to access your VM.
+5. Set your source IP range. We recommend you restrict this to your own IP address or your corporate network rather than
+   `0.0.0.0/0` which will allow anyone to access your VM.
 6. Under **Protocols and ports** allow TCP connections on ports `22,8786,8787,8888`.
 
 ### Assign it to the VM
@@ -61,7 +67,8 @@ Next we need to connect to the VM.
 
 ## Clean up
 
-Once you are finished head back to the [Deployments](https://console.cloud.google.com/dm/deployments) page and delete the marketplace deployment you created.
+Once you are finished head back to the [Deployments](https://console.cloud.google.com/dm/deployments) page and delete
+the marketplace deployment you created.
 
 ```{relatedexamples}
 

--- a/source/cloud/gcp/dataproc.md
+++ b/source/cloud/gcp/dataproc.md
@@ -1,10 +1,15 @@
 # Dataproc
 
-RAPIDS can be deployed on Google Cloud Dataproc using Dask. For more details, see our **[detailed instructions and helper scripts.](https://github.com/GoogleCloudDataproc/initialization-actions/tree/master/rapids)**
+RAPIDS can be deployed on Google Cloud Dataproc using Dask. For more details, see our **[detailed instructions and
+helper scripts.](https://github.com/GoogleCloudDataproc/initialization-actions/tree/master/rapids)**
 
-**0. Copy initialization actions to your own Cloud Storage bucket.** Don't create clusters that reference initialization actions located in `gs://goog-dataproc-initialization-actions-REGION` public buckets. These scripts are provided as reference implementations and are synchronized with ongoing [GitHub repository](https://github.com/GoogleCloudDataproc/initialization-actions) changes.
+**0. Copy initialization actions to your own Cloud Storage bucket.** Don't create clusters that reference initialization
+actions located in `gs://goog-dataproc-initialization-actions-REGION` public buckets. These scripts are provided as
+reference implementations and are synchronized with ongoing [GitHub
+repository](https://github.com/GoogleCloudDataproc/initialization-actions) changes.
 
-It is strongly recommended that you copy the initialization scripts into your own Storage bucket to prevent unintended upgrades from upstream in the cluster:
+It is strongly recommended that you copy the initialization scripts into your own Storage bucket to prevent unintended
+upgrades from upstream in the cluster:
 
 ```console
 $ REGION=<region>
@@ -16,12 +21,15 @@ $ gsutil cp gs://goog-dataproc-initialization-actions-${REGION}/rapids/rapids.sh
 
 ```
 
-**1. Create Dataproc cluster with Dask RAPIDS.** Use the gcloud command to create a new cluster. Because of an Anaconda version conflict, script deployment on older images is slow, we recommend using Dask with Dataproc 2.0+.
+**1. Create Dataproc cluster with Dask RAPIDS.** Use the gcloud command to create a new cluster. Because of an Anaconda
+version conflict, script deployment on older images is slow, we recommend using Dask with Dataproc 2.0+.
 
 ```{warning}
-At the time of writing [Dataproc only supports RAPIDS version 23.12 and earlier with CUDA<=11.8 and Ubuntu 18.04](https://github.com/GoogleCloudDataproc/initialization-actions/issues/1137).
+At the time of writing [Dataproc only supports RAPIDS version 23.12 and earlier with CUDA<=11.8 and Ubuntu
+18.04](https://github.com/GoogleCloudDataproc/initialization-actions/issues/1137).
 
-Please ensure that your setup complies with this compatibility requirement. Using newer RAPIDS versions may result in unexpected behavior or errors.
+Please ensure that your setup complies with this compatibility requirement. Using newer RAPIDS versions may result in
+unexpected behavior or errors.
 ```
 
 ```console
@@ -50,9 +58,12 @@ $ gcloud dataproc clusters create $CLUSTER_NAME\
 [REGION] = name of region where cluster is to be created.\
 [DASK_RUNTIME] = Dask runtime could be set to either yarn or standalone.
 
-**2. Run Dask RAPIDS Workload.** Once the cluster has been created, the Dask scheduler listens for workers on `port 8786`, and its status dashboard is on `port 8787` on the Dataproc master node.
+**2. Run Dask RAPIDS Workload.** Once the cluster has been created, the Dask scheduler listens for workers on `port
+8786`, and its status dashboard is on `port 8787` on the Dataproc master node.
 
-To connect to the Dask web interface, you will need to create an SSH tunnel as described in the [Dataproc web interfaces documentation.](https://cloud.google.com/dataproc/docs/concepts/accessing/cluster-web-interfaces) You can also connect using the Dask Client Python API from a Jupyter notebook, or from a Python script or interpreter session.
+To connect to the Dask web interface, you will need to create an SSH tunnel as described in the [Dataproc web interfaces
+documentation.](https://cloud.google.com/dataproc/docs/concepts/accessing/cluster-web-interfaces) You can also connect
+using the Dask Client Python API from a Jupyter notebook, or from a Python script or interpreter session.
 
 ```{relatedexamples}
 

--- a/source/cloud/gcp/gke.md
+++ b/source/cloud/gcp/gke.md
@@ -4,13 +4,16 @@ review_priority: "p1"
 
 # Google Kubernetes Engine
 
-RAPIDS can be deployed on Google Cloud via the [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine) (GKE).
+RAPIDS can be deployed on Google Cloud via the [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine)
+(GKE).
 
 To run RAPIDS you'll need a Kubernetes cluster with GPUs available.
 
 ## Prerequisites
 
-First you'll need to have the [`gcloud` CLI tool](https://cloud.google.com/sdk/gcloud) installed along with [`kubectl`](https://kubernetes.io/docs/tasks/tools/), [`helm`](https://helm.sh/docs/intro/install/), etc for managing Kubernetes.
+First you'll need to have the [`gcloud` CLI tool](https://cloud.google.com/sdk/gcloud) installed along with
+[`kubectl`](https://kubernetes.io/docs/tasks/tools/), [`helm`](https://helm.sh/docs/intro/install/), etc for managing
+Kubernetes.
 
 Ensure you are logged into the `gcloud` CLI.
 
@@ -28,7 +31,8 @@ gcloud container clusters create rapids-gpu-kubeflow \
   --zone us-central1-c --release-channel stable
 ```
 
-With this command, you’ve launched a GKE cluster called `rapids-gpu-kubeflow`. You’ve specified that it should use nodes of type a2-highgpu-2g, each with two A100 GPUs.
+With this command, you’ve launched a GKE cluster called `rapids-gpu-kubeflow`. You’ve specified that it should use nodes
+of type a2-highgpu-2g, each with two A100 GPUs.
 
 ## Get the cluster credentials
 
@@ -37,11 +41,13 @@ gcloud container clusters get-credentials rapids-gpu-kubeflow \
     --region=us-central1-c
 ```
 
-With this command, your `kubeconfig` is updated with credentials and endpoint information for the `rapids-gpu-kubeflow` cluster.
+With this command, your `kubeconfig` is updated with credentials and endpoint information for the `rapids-gpu-kubeflow`
+cluster.
 
 ## Install drivers
 
-Next, [install the NVIDIA drivers](https://cloud.google.com/kubernetes-engine/docs/how-to/gpus#installing_drivers) onto each node.
+Next, [install the NVIDIA drivers](https://cloud.google.com/kubernetes-engine/docs/how-to/gpus#installing_drivers) onto
+each node.
 
 ```console
 $ kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/master/nvidia-driver-installer/cos/daemonset-preloaded-latest.yaml
@@ -68,7 +74,8 @@ After your drivers are installed, you are ready to test your cluster.
 
 ## Install RAPIDS
 
-Now that you have a GPU enables Kubernetes cluster on GKE you can install RAPIDS with [any of the supported methods](../../platforms/kubernetes).
+Now that you have a GPU enables Kubernetes cluster on GKE you can install RAPIDS with [any of the supported
+methods](../../platforms/kubernetes).
 
 ## Clean up
 

--- a/source/cloud/gcp/index.md
+++ b/source/cloud/gcp/index.md
@@ -9,7 +9,10 @@ html_theme.sidebar_secondary.remove: true
 
 ```
 
-RAPIDS can be deployed on Google Cloud Platform in several ways. Google Cloud supports various kinds of GPU VMs for different needs. Please visit the Google Cloud documentation for [an overview of GPU VM sizes](https://cloud.google.com/compute/docs/gpus) and [GPU VM availability by region](https://cloud.google.com/compute/docs/gpus/gpu-regions-zones).
+RAPIDS can be deployed on Google Cloud Platform in several ways. Google Cloud supports various kinds of GPU VMs for
+different needs. Please visit the Google Cloud documentation for [an overview of GPU VM
+sizes](https://cloud.google.com/compute/docs/gpus) and [GPU VM availability by
+region](https://cloud.google.com/compute/docs/gpus/gpu-regions-zones).
 
 ```{toctree}
 ---

--- a/source/cloud/gcp/vertex-ai.md
+++ b/source/cloud/gcp/vertex-ai.md
@@ -8,30 +8,38 @@ RAPIDS can be deployed on [Vertex AI Workbench](https://cloud.google.com/vertex-
 
 ## Create a new Notebook Instance
 
-1. From the Google Cloud UI, navigate to [**Vertex AI**](https://console.cloud.google.com/vertex-ai/workbench/user-managed) -> Notebook -> **Workbench**
+1. From the Google Cloud UI, navigate to [**Vertex
+   AI**](https://console.cloud.google.com/vertex-ai/workbench/user-managed) -> Notebook -> **Workbench**
 2. Select **Instances** and select **+ CREATE NEW**.
 3. In the **Details** section give the instance a name.
 4. Check the "Attach 1 NVIDIA T4 GPU" option.
 5. After customizing any other aspects of the machine you wish, click **CREATE**.
 
 ```{tip}
-If you want to select a different GPU or select other hardware options you can select "Advanced Options" at the bottom and then make changes in the "Machine type" section.
+If you want to select a different GPU or select other hardware options you can select "Advanced Options" at the bottom
+and then make changes in the "Machine type" section.
 ```
 
 ## Install RAPIDS
 
-Once the instance has started select **OPEN JUPYTER LAB** and at the top of a notebook install the RAPIDS libraries you wish to use.
+Once the instance has started select **OPEN JUPYTER LAB** and at the top of a notebook install the RAPIDS libraries you
+wish to use.
 
 ```{warning}
-Installing RAPIDS via `pip` in the default environment is [not currently possible](https://github.com/rapidsai/deployment/issues/517), for now you must create a new `conda` environment.
+Installing RAPIDS via `pip` in the default environment is [not currently
+possible](https://github.com/rapidsai/deployment/issues/517), for now you must create a new `conda` environment.
 
-Vertex AI currently ships with CUDA Toolkit 11 system packages as of the [Jan 2025 Vertex AI release](https://cloud.google.com/vertex-ai/docs/release-notes#January_31_2025).
-The default Python environment also contains the `cupy-cuda12x` package. This means it's not possible to install RAPIDS package like `cudf` via `pip` as `cudf-cu12` will conflict with the CUDA Toolkit version but `cudf-cu11` will conflict with the `cupy` version.
+Vertex AI currently ships with CUDA Toolkit 11 system packages as of the [Jan 2025 Vertex AI
+release](https://cloud.google.com/vertex-ai/docs/release-notes#January_31_2025).
+The default Python environment also contains the `cupy-cuda12x` package. This means it's not possible to install RAPIDS
+package like `cudf` via `pip` as `cudf-cu12` will conflict with the CUDA Toolkit version but `cudf-cu11` will conflict
+with the `cupy` version.
 
 You can find out your current system CUDA Toolkit version by running `ls -ld /usr/local/cuda*`.
 ```
 
-You can create a new RAPIDS conda environment and register it with `ipykernel` for use in Jupyter Lab. Open a new terminal in Jupyter and run the following commands.
+You can create a new RAPIDS conda environment and register it with `ipykernel` for use in Jupyter Lab. Open a new
+terminal in Jupyter and run the following commands.
 
 ```bash
 # Create a new environment

--- a/source/cloud/ibm/virtual-server.md
+++ b/source/cloud/ibm/virtual-server.md
@@ -7,31 +7,31 @@ Driver](https://www.nvidia.co.uk/Download/index.aspx) and the [NVIDIA Container
 Runtime](https://developer.nvidia.com/nvidia-container-runtime).
 
 1. Open the [**Virtual Server Dashboard**](https://cloud.ibm.com/vpc-ext/compute/vs).
-2. Select **Create**.
-3. Give the server a **name** and select your **resource group**.
-4. Under **Operating System** choose **Ubuntu Linux**.
-5. Under **Profile** select **View all profiles** and select a profile with NVIDIA GPUs.
-6. Under **SSH Keys** choose your SSH key.
-7. Under network settings create a security group (or choose an existing) that allows SSH access on port `22` and also
+1. Select **Create**.
+1. Give the server a **name** and select your **resource group**.
+1. Under **Operating System** choose **Ubuntu Linux**.
+1. Under **Profile** select **View all profiles** and select a profile with NVIDIA GPUs.
+1. Under **SSH Keys** choose your SSH key.
+1. Under network settings create a security group (or choose an existing) that allows SSH access on port `22` and also
    allow ports `8888,8786,8787` to access Jupyter and Dask.
-8. Select **Create Virtual Server**.
+1. Select **Create Virtual Server**.
 
 ## Create floating IP
 
 To access the virtual server we need to attach a public IP address.
 
 1. Open [**Floating IPs**](https://cloud.ibm.com/vpc-ext/network/floatingIPs)
-2. Select **Reserve**.
-3. Give the Floating IP a **name**.
-4. Under **Resource to bind** select the virtual server you just created.
+1. Select **Reserve**.
+1. Give the Floating IP a **name**.
+1. Under **Resource to bind** select the virtual server you just created.
 
 ## Connect to the instance
 
 Next we need to connect to the instance.
 
 1. Open [**Floating IPs**](https://cloud.ibm.com/vpc-ext/network/floatingIPs)
-2. Locate the IP you just created and note the address.
-3. In your terminal run `ssh root@<ip address>`
+1. Locate the IP you just created and note the address.
+1. In your terminal run `ssh root@<ip address>`
 
 ```{note}
 For a short guide on launching your instance and accessing it, read the
@@ -43,8 +43,8 @@ For a short guide on launching your instance and accessing it, read the
 Next we need to install the NVIDIA drivers and container runtime.
 
 1. Ensure build essentials are installed `apt-get update && apt-get install build-essential -y`.
-2. Install the [NVIDIA drivers](https://www.nvidia.com/Download/index.aspx?lang=en-us).
-3. Install [Docker and the NVIDIA Docker runtime](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html).
+1. Install the [NVIDIA drivers](https://www.nvidia.com/Download/index.aspx?lang=en-us).
+1. Install [Docker and the NVIDIA Docker runtime](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html).
 
 ````{dropdown} How do I check everything installed successfully?
 :color: info

--- a/source/cloud/ibm/virtual-server.md
+++ b/source/cloud/ibm/virtual-server.md
@@ -2,33 +2,36 @@
 
 ## Create Instance
 
-Create a new [Virtual Server (for VPC)](https://www.ibm.com/cloud/virtual-servers) with GPUs, the [NVIDIA Driver](https://www.nvidia.co.uk/Download/index.aspx) and the [NVIDIA Container Runtime](https://developer.nvidia.com/nvidia-container-runtime).
+Create a new [Virtual Server (for VPC)](https://www.ibm.com/cloud/virtual-servers) with GPUs, the [NVIDIA
+Driver](https://www.nvidia.co.uk/Download/index.aspx) and the [NVIDIA Container
+Runtime](https://developer.nvidia.com/nvidia-container-runtime).
 
 1. Open the [**Virtual Server Dashboard**](https://cloud.ibm.com/vpc-ext/compute/vs).
-1. Select **Create**.
-1. Give the server a **name** and select your **resource group**.
-1. Under **Operating System** choose **Ubuntu Linux**.
-1. Under **Profile** select **View all profiles** and select a profile with NVIDIA GPUs.
-1. Under **SSH Keys** choose your SSH key.
-1. Under network settings create a security group (or choose an existing) that allows SSH access on port `22` and also allow ports `8888,8786,8787` to access Jupyter and Dask.
-1. Select **Create Virtual Server**.
+2. Select **Create**.
+3. Give the server a **name** and select your **resource group**.
+4. Under **Operating System** choose **Ubuntu Linux**.
+5. Under **Profile** select **View all profiles** and select a profile with NVIDIA GPUs.
+6. Under **SSH Keys** choose your SSH key.
+7. Under network settings create a security group (or choose an existing) that allows SSH access on port `22` and also
+   allow ports `8888,8786,8787` to access Jupyter and Dask.
+8. Select **Create Virtual Server**.
 
 ## Create floating IP
 
 To access the virtual server we need to attach a public IP address.
 
 1. Open [**Floating IPs**](https://cloud.ibm.com/vpc-ext/network/floatingIPs)
-1. Select **Reserve**.
-1. Give the Floating IP a **name**.
-1. Under **Resource to bind** select the virtual server you just created.
+2. Select **Reserve**.
+3. Give the Floating IP a **name**.
+4. Under **Resource to bind** select the virtual server you just created.
 
 ## Connect to the instance
 
 Next we need to connect to the instance.
 
 1. Open [**Floating IPs**](https://cloud.ibm.com/vpc-ext/network/floatingIPs)
-1. Locate the IP you just created and note the address.
-1. In your terminal run `ssh root@<ip address>`
+2. Locate the IP you just created and note the address.
+3. In your terminal run `ssh root@<ip address>`
 
 ```{note}
 For a short guide on launching your instance and accessing it, read the
@@ -40,8 +43,8 @@ For a short guide on launching your instance and accessing it, read the
 Next we need to install the NVIDIA drivers and container runtime.
 
 1. Ensure build essentials are installed `apt-get update && apt-get install build-essential -y`.
-1. Install the [NVIDIA drivers](https://www.nvidia.com/Download/index.aspx?lang=en-us).
-1. Install [Docker and the NVIDIA Docker runtime](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html).
+2. Install the [NVIDIA drivers](https://www.nvidia.com/Download/index.aspx?lang=en-us).
+3. Install [Docker and the NVIDIA Docker runtime](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html).
 
 ````{dropdown} How do I check everything installed successfully?
 :color: info

--- a/source/cloud/nvidia/brev.md
+++ b/source/cloud/nvidia/brev.md
@@ -4,7 +4,9 @@ review_priority: "p0"
 
 # NVIDIA Brev
 
-The [NVIDIA Brev](https://brev.nvidia.com/) platform provides you a one stop menu of available GPU instances across many cloud providers, including [Amazon Web Services](https://aws.amazon.com/) and [Google Cloud](https://cloud.google.com), with CUDA, Python, Jupyter Lab, all set up.
+The [NVIDIA Brev](https://brev.nvidia.com/) platform provides you a one stop menu of available GPU instances across many
+cloud providers, including [Amazon Web Services](https://aws.amazon.com/) and [Google Cloud](https://cloud.google.com),
+with CUDA, Python, Jupyter Lab, all set up.
 
 ## Brev Instance Setup
 
@@ -43,22 +45,25 @@ our [Single-cell Analysis Blueprint](https://github.com/clara-parabricks-workflo
 However, you can use this to create quick-start templates for many different kinds of projects when you want users to
 drop into an environment where they can quickly prototype.
 
-You can read more about Brev Launchables in the [Getting Started Guide](https://docs.nvidia.com/brev/latest/launchables-getting-started.html).
+You can read more about Brev Launchables in the [Getting Started
+Guide](https://docs.nvidia.com/brev/latest/launchables-getting-started.html).
 
 1. Go to [Brev’s Launchable Creator](https://brev.nvidia.com/launchables/create) (requires account)
 2. When asked **How would you like to provide your code files?** select the option that corresponds to your use case. If
-   you are using a blueprint, you will select "I have code files in a git repository" paste a link to the blueprint GitHub
-   repository here. Otherwise, select "I don't have any code files".
+   you are using a blueprint, you will select "I have code files in a git repository" paste a link to the blueprint
+   GitHub repository here. Otherwise, select "I don't have any code files".
 3. When asked **What type of runtime environment do you need?** select "With container(s)".
 4. When prompted to **Choose a Container Configuration**, you have two options:
    1. **If you need a custom container**: Select "Docker Compose" and click on the toggle to select "I have an existing
-      `docker-compose.yaml` file". Under **Upload Docker Compose** select "Provide GitHub/Gitlab URL" and provide a link to
-      a Docker Compose YAML file (e.g. [docker-compose-nb-2412.yaml](https://github.com/clara-parabricks-workflows/single-cell-analysis-blueprint/blob/main/docker/brev/docker-compose-nb-2412.yaml)).
+      `docker-compose.yaml` file". Under **Upload Docker Compose** select "Provide GitHub/Gitlab URL" and provide a link
+      to a Docker Compose YAML file (e.g.
+      [docker-compose-nb-2412.yaml](https://github.com/clara-parabricks-workflows/single-cell-analysis-blueprint/blob/main/docker/brev/docker-compose-nb-2412.yaml)).
       Click "Validate". Note, you needto pass a link to the file in GitHub, not to the `raw.github.com` file.
    2. **If you need a standard container**: Select "Featured Container" and then select the "NVIDIA RAPIDS" container.
 5. On the next page, when asked **Do you want a Jupyter Notebook experience?**, if you are using a standard container,
    you will be told there is a preconfigured Jupyter experience. Click "Next". If you are using a custom container with
-   Docker Compose, follow the instructions associated with the Blueprint you are using. Some will include Jupyter pre-installed.
+   Docker Compose, follow the instructions associated with the Blueprint you are using. Some will include Jupyter
+   pre-installed.
 6. In the section titled **Do you need to expose services?**, if you are using a standard container, you will not need
    to edit anything. If you are using a custom configuration, make sure to follow the instructions associated with your
    blueprint.
@@ -85,7 +90,8 @@ To create and use a Jupyter Notebook, click "Open Notebook" at the top right aft
 
 ### 2. Brev CLI Install
 
-If you want to access your launched Brev instance(s) via Visual Studio Code or SSH using terminal, you need to install the [Brev CLI according to these instructions](https://docs.nvidia.com/brev/latest/brev-cli.html) or this code below:
+If you want to access your launched Brev instance(s) via Visual Studio Code or SSH using terminal, you need to install
+the [Brev CLI according to these instructions](https://docs.nvidia.com/brev/latest/brev-cli.html) or this code below:
 
 ```bash
 sudo bash -c "$(curl -fsSL https://raw.githubusercontent.com/brevdev/brev-cli/main/bin/install-latest.sh)" && brev login
@@ -111,7 +117,8 @@ brev shell <instance-id>
 
 ##### Forwarding a Port Locally
 
-Assuming your Jupyter Notebook is running on port `8888` in your Brev environment, you can forward this port to your local machine using the following SSH command:
+Assuming your Jupyter Notebook is running on port `8888` in your Brev environment, you can forward this port to your
+local machine using the following SSH command:
 
 ```bash
 ssh -L 8888:localhost:8888 <username>@<ip> -p 22
@@ -129,13 +136,16 @@ Replace `username` with your username and `ip` with the ip listed if it's differ
 
 ##### Accessing the Service
 
-After running the command, open your web browser and navigate to your local host. You will be able to access the Jupyter Notebook running in your Brev environment as if it were running locally.
+After running the command, open your web browser and navigate to your local host. You will be able to access the Jupyter
+Notebook running in your Brev environment as if it were running locally.
 
 #### 3. Access the Jupyter Notebook via the Tunnel
 
-The "Deployments" section will show that your Jupyter Notebook is running on port `8888`, and it is accessible via a shareable URL Ex: `jupyter0-i55ymhsr8.brevlab.com`.
+The "Deployments" section will show that your Jupyter Notebook is running on port `8888`, and it is accessible via a
+shareable URL Ex: `jupyter0-i55ymhsr8.brevlab.com`.
 
-Click on the link or copy and paste the URL into your web browser's address bar to access the Jupyter Notebook interface directly.
+Click on the link or copy and paste the URL into your web browser's address bar to access the Jupyter Notebook interface
+directly.
 
 ##### 4. Share the Service
 
@@ -163,7 +173,8 @@ print(gdf)
 ## Resources and tips
 
 - [Brev Docs](https://brev.dev/)
-- Please note: Git is not preinstalled in the RAPIDS container, but can be installed into the container when it is running using
+- Please note: Git is not preinstalled in the RAPIDS container, but can be installed into the container when it is
+  running using
 
 ```bash
 apt update

--- a/source/developer/ci/github-actions.md
+++ b/source/developer/ci/github-actions.md
@@ -2,41 +2,61 @@
 
 GitHub Actions is a popular way to automatically run tests against code hosted on GitHub.
 
-GitHub's free tier includes basic runners (the machines that will run your code) and the paid tier includes support for [hosted runners with NVIDIA GPUs](https://github.blog/changelog/2024-07-08-github-actions-gpu-hosted-runners-are-now-generally-available/). This allows GPU specific code to be exercised as part of a CI workflow.
+GitHub's free tier includes basic runners (the machines that will run your code) and the paid tier includes support for
+[hosted runners with NVIDIA
+GPUs](https://github.blog/changelog/2024-07-08-github-actions-gpu-hosted-runners-are-now-generally-available/). This
+allows GPU specific code to be exercised as part of a CI workflow.
 
 ## Cost
 
-As GPU runners are not included in the free tier projects will have to pay for GPU CI resources. Typically GPU runners cost a few cents per minute, check out the [GitHub documentation](https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#per-minute-rates-for-gpu-powered-larger-runners) for more information.
+As GPU runners are not included in the free tier projects will have to pay for GPU CI resources. Typically GPU runners
+cost a few cents per minute, check out the [GitHub
+documentation](https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#per-minute-rates-for-gpu-powered-larger-runners)
+for more information.
 
-We recommend that projects set a [spending limit](https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#about-spending-limits) on their account/organization. That way your monthly bill will never be a surprise.
+We recommend that projects set a [spending
+limit](https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#about-spending-limits)
+on their account/organization. That way your monthly bill will never be a surprise.
 
-We also recommend that you only run GPU CI intentionally rather than on every pull request from every contributor. Check out the best practices section for more information.
+We also recommend that you only run GPU CI intentionally rather than on every pull request from every contributor. Check
+out the best practices section for more information.
 
 ## Getting started
 
 ### Setting up your GPU runners
 
-First you'll need to set up a way to pay GitHub. You can do this by [adding a payment method](https://docs.github.com/en/billing/managing-your-github-billing-settings/adding-or-editing-a-payment-method) to your organisation.
+First you'll need to set up a way to pay GitHub. You can do this by [adding a payment
+method](https://docs.github.com/en/billing/managing-your-github-billing-settings/adding-or-editing-a-payment-method) to
+your organisation.
 
-While you're in your billing settings you should also decide what the maximum is that you wish to spend on GPU CI functionality and then set a [spending limit](https://docs.github.com/en/billing/managing-billing-for-github-actions/managing-your-spending-limit-for-github-actions) on your account.
+While you're in your billing settings you should also decide what the maximum is that you wish to spend on GPU CI
+functionality and then set a [spending
+limit](https://docs.github.com/en/billing/managing-billing-for-github-actions/managing-your-spending-limit-for-github-actions)
+on your account.
 
-Next you can go into the GitHub Actions settings for your account and configure a [larger runner](https://docs.github.com/en/actions/using-github-hosted-runners/using-larger-runners/about-larger-runners). You can find this settings page by visiting `https://github.com/organizations/<YOUR_ORG>/settings/actions/runners`.
+Next you can go into the GitHub Actions settings for your account and configure a [larger
+runner](https://docs.github.com/en/actions/using-github-hosted-runners/using-larger-runners/about-larger-runners). You
+can find this settings page by visiting `https://github.com/organizations/<YOUR_ORG>/settings/actions/runners`.
 
-![Screenshot of the GitHub Actions runner configuration page with the new runner button highlighted](/_static/images/developer/ci/github-actions/new-hosted-runner.png)
+![Screenshot of the GitHub Actions runner configuration page with the new runner button
+highlighted](/_static/images/developer/ci/github-actions/new-hosted-runner.png)
 
-Next you need to give your runner a name, for example `linux-nvidia-gpu`, you'll need to remember this for configuring your workflows later. Then you need to choose your runner settings:
+Next you need to give your runner a name, for example `linux-nvidia-gpu`, you'll need to remember this for configuring
+your workflows later. Then you need to choose your runner settings:
 
 - Under "Platform" select "Linux x64"
 - Under "Image" switch to the "Partner" tab and choose "NVIDIA GPU-Optimized Image for AI and HPC"
 - Under "Size" switch to the "GPU-powered" tab and select your preferred NVIDIA hardware
 
-![Screenshot of the GitHub Actions runner configuration page a new GPU runner configured](/_static/images/developer/ci/github-actions/new-runner-config.png)
+![Screenshot of the GitHub Actions runner configuration page a new GPU runner
+configured](/_static/images/developer/ci/github-actions/new-runner-config.png)
 
 Then set your preferred maximum concurrency and then choose "Create runner".
 
 ### Configuring your workflows
 
-To configure your workflow to use your new GPU runners you need to set the `runs-on` property to match the name you gave the runner group.
+To configure your workflow to use your new GPU runners you need to set the `runs-on` property to match the name you gave
+the runner group.
 
 ```yaml
 name: GitHub Actions GPU Demo
@@ -52,11 +72,15 @@ jobs:
 
 ## Best practices
 
-Adding GitHub Actions runners to your project that cost money requires you to put some extra thought into when you want those workflows to run. Setting a spending cap allows you to keep control of how much you are spending, but you still want to get the most for your money. Here are some tips on when to effectively use GPU runners in your projects.
+Adding GitHub Actions runners to your project that cost money requires you to put some extra thought into when you want
+those workflows to run. Setting a spending cap allows you to keep control of how much you are spending, but you still
+want to get the most for your money. Here are some tips on when to effectively use GPU runners in your projects.
 
 ### Use labels to trigger workloads
 
-Instead of always triggering your GPU workflows on every push or pull request you can use labels to trigger workflows. This is a great option if your project is public and anyone can make a pull request with any arbitrary code. You may want to have a mechanism for a trusted maintainer or collaborator to trigger the GPU workflow manually.
+Instead of always triggering your GPU workflows on every push or pull request you can use labels to trigger workflows.
+This is a great option if your project is public and anyone can make a pull request with any arbitrary code. You may
+want to have a mechanism for a trusted maintainer or collaborator to trigger the GPU workflow manually.
 
 The scikit-learn project solved this by having a label that triggers the workflow.
 
@@ -75,13 +99,19 @@ jobs:
     steps: ...
 ```
 
-The above config specifies a workflow should only be run when the `GPU CI` label is added to the pull request. They then have a second [label remover workflow](https://github.com/scikit-learn/scikit-learn/blob/9d39f57399d6f1f7d8e8d4351dbc3e9244b98d28/.github/workflows/cuda-label-remover.yml) which removed the label again, which allows a maintainer to add it again in the future to trigger the GPU CI workflow any number of times during the review of the pull request.
+The above config specifies a workflow should only be run when the `GPU CI` label is added to the pull request. They then
+have a second [label remover
+workflow](https://github.com/scikit-learn/scikit-learn/blob/9d39f57399d6f1f7d8e8d4351dbc3e9244b98d28/.github/workflows/cuda-label-remover.yml)
+which removed the label again, which allows a maintainer to add it again in the future to trigger the GPU CI workflow
+any number of times during the review of the pull request.
 
 ### Run nightly
 
-Some projects might not need to run GPU tests for every pull request, but instead might prefer to run a nightly regression test to ensure that nothing that has been merged has broken GPU functionality.
+Some projects might not need to run GPU tests for every pull request, but instead might prefer to run a nightly
+regression test to ensure that nothing that has been merged has broken GPU functionality.
 
-You can configure a GitHub Actions workflow to run on a schedule and use [an action](https://github.com/marketplace/actions/failed-build-issue) to open an issue if the workflow fails.
+You can configure a GitHub Actions workflow to run on a schedule and use [an
+action](https://github.com/marketplace/actions/failed-build-issue) to open an issue if the workflow fails.
 
 ```yaml
 name: Nightly GPU Tests
@@ -108,7 +138,9 @@ jobs:
 
 ### Run only on certain codepaths
 
-You may also want to only run your GPU CI tests when code at certain paths has been modified. To do this you can use the [`on.push.paths` filter](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-including-paths).
+You may also want to only run your GPU CI tests when code at certain paths has been modified. To do this you can use the
+[`on.push.paths`
+filter](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-including-paths).
 
 ```yaml
 name: GPU Tests

--- a/source/guides/azure/infiniband.md
+++ b/source/guides/azure/infiniband.md
@@ -298,8 +298,8 @@ python -m ucp.benchmarks.send_recv --server-dev 0 --client-dev 1 -o rmm --reuse-
 UCX_TLS=tcp,cuda_copy python -m ucp.benchmarks.send_recv --server-dev 0 --client-dev 1 -o rmm --reuse-alloc -n 128MiB
 ```
 
-We expect the first case above to have much higher bandwidth than the second. If you happen to have both
-NVLink and InfiniBand connectivity, then you may limit to the specific transport by specifying `UCX_TLS`, e.g.:
+We expect the first case above to have much higher bandwidth than the second. If you happen to have both NVLink and
+InfiniBand connectivity, then you may limit to the specific transport by specifying `UCX_TLS`, e.g.:
 
 ```shell
 # NVLink (if available) or TCP

--- a/source/guides/azure/infiniband.md
+++ b/source/guides/azure/infiniband.md
@@ -34,7 +34,9 @@ sudo apt-get upgrade -y
 
 ### NVIDIA Drivers
 
-The commands below should work for Ubuntu. See the [CUDA Toolkit documentation](https://docs.nvidia.com/cuda/index.html#installation-guides) for details on installing on other operating systems.
+The commands below should work for Ubuntu. See the [CUDA Toolkit
+documentation](https://docs.nvidia.com/cuda/index.html#installation-guides) for details on installing on other operating
+systems.
 
 ```shell
 sudo apt-get install -y linux-headers-$(uname -r)
@@ -121,8 +123,8 @@ Mon Nov 14 20:32:39 2022
 On Ubuntu 24.04
 
 ```shell
-sudo apt-get install -y automake dh-make git libcap2 libnuma-dev libtool make pkg-config udev curl librdmacm-dev rdma-core \
-    libgfortran5 bison chrpath flex graphviz gfortran tk  quilt swig tcl ibverbs-utils
+sudo apt-get install -y automake dh-make git libcap2 libnuma-dev libtool make pkg-config udev curl librdmacm-dev \
+  rdma-core libgfortran5 bison chrpath flex graphviz gfortran tk  quilt swig tcl ibverbs-utils
 ```
 
 Check install
@@ -257,10 +259,14 @@ Then start a new shell.
 
 Create a conda environment (see [UCX-Py](https://ucx-py.readthedocs.io/en/latest/install.html) docs)
 
+<!-- markdownlint-disable -->
+
 ```shell
 mamba create -n ucxpy {{ rapids_conda_channels }} {{ rapids_conda_packages }} ipython ucx-proc=*=gpu ucx ucx-py dask distributed numpy cupy pytest pynvml -y
 mamba activate ucxpy
 ```
+
+<!-- markdownlint-enable -->
 
 Clone UCX-Py repo locally
 
@@ -278,7 +284,8 @@ pytest -vs tests/
 pytest -vs ucp/_libs/tests/
 ```
 
-Now check to see if InfiniBand works, for that you can run some of the benchmarks that we include in UCX-Py, for example:
+Now check to see if InfiniBand works, for that you can run some of the benchmarks that we include in UCX-Py, for
+example:
 
 ```shell
 # cd out of the ucx-py directory
@@ -305,20 +312,21 @@ UCX_TLS=tcp,cuda_copy,rc
 
 ## Run Benchmarks
 
-Finally, let's run the [merge benchmark](https://github.com/rapidsai/dask-cuda/blob/HEAD/dask_cuda/benchmarks/local_cudf_merge.py) from `dask-cuda`.
+Finally, let's run the [merge
+benchmark](https://github.com/rapidsai/dask-cuda/blob/HEAD/dask_cuda/benchmarks/local_cudf_merge.py) from `dask-cuda`.
 
 This benchmark uses Dask to perform a merge of two dataframes that are distributed across all the available GPUs on your
 VM. Merges are a challenging benchmark in a distributed setting since they require communication-intensive shuffle
-operations of the participating dataframes
-(see the [Dask documentation](https://docs.dask.org/en/stable/dataframe-best-practices.html#avoid-full-data-shuffling)
-for more on this type of operation). To perform the merge, each dataframe is shuffled such that rows with the same join
-key appear on the same GPU. This results in an [all-to-all](<https://en.wikipedia.org/wiki/All-to-all_(parallel_pattern)>)
-communication pattern which requires a lot of communication between the GPUs. As a result, network
-performance will be very important for the throughput of the benchmark.
+operations of the participating dataframes (see the [Dask
+documentation](https://docs.dask.org/en/stable/dataframe-best-practices.html#avoid-full-data-shuffling) for more on this
+type of operation). To perform the merge, each dataframe is shuffled such that rows with the same join key appear on the
+same GPU. This results in an [all-to-all](<https://en.wikipedia.org/wiki/All-to-all_(parallel_pattern)>) communication
+pattern which requires a lot of communication between the GPUs. As a result, network performance will be very important
+for the throughput of the benchmark.
 
-Below we are running for devices 0 through 7 (inclusive), you will want to adjust that for the number of devices available on your VM, the default
-is to run on GPU 0 only. Additionally, `--chunk-size 100_000_000` is a safe value for 32GB GPUs, you may
-adjust that proportional to the size of the GPU you have (it scales linearly, so `50_000_000` should
+Below we are running for devices 0 through 7 (inclusive), you will want to adjust that for the number of devices
+available on your VM, the default is to run on GPU 0 only. Additionally, `--chunk-size 100_000_000` is a safe value for
+32GB GPUs, you may adjust that proportional to the size of the GPU you have (it scales linearly, so `50_000_000` should
 be good for 16GB or `150_000_000` for 48GB).
 
 ```shell

--- a/source/guides/caching-docker-images.md
+++ b/source/guides/caching-docker-images.md
@@ -1,12 +1,17 @@
 # Caching Docker Images For Autoscaling Workloads
 
-The [Dask Autoscaler](https://kubernetes.dask.org/en/latest/operator_resources.html#daskautoscaler) leverages Dask's adaptive mode and allows the scheduler to scale the number of workers up and down based on the task graph.
+The [Dask Autoscaler](https://kubernetes.dask.org/en/latest/operator_resources.html#daskautoscaler) leverages Dask's
+adaptive mode and allows the scheduler to scale the number of workers up and down based on the task graph.
 
-When scaling the Dask cluster up or down, there is no guarantee that newly created worker pods will be scheduled on the same node as previously removed workers. As a result, when a new node is allocated for a worker pod, the cluster will incur a pull penalty due to the need to download the Docker image.
+When scaling the Dask cluster up or down, there is no guarantee that newly created worker pods will be scheduled on the
+same node as previously removed workers. As a result, when a new node is allocated for a worker pod, the cluster will
+incur a pull penalty due to the need to download the Docker image.
 
 ## Using a Daemonset to cache images
 
-To guarantee that each node runs a consistent workload, we will deploy a Kubernetes [DaemonSet](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/) utilizing the RAPIDS image. This DaemonSet will prevent Dask worker pods created from this image from entering a pending state when tasks are scheduled.
+To guarantee that each node runs a consistent workload, we will deploy a Kubernetes
+[DaemonSet](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/) utilizing the RAPIDS image. This
+DaemonSet will prevent Dask worker pods created from this image from entering a pending state when tasks are scheduled.
 
 This is an example manifest to deploy a Daemonset with the RAPIDS container.
 
@@ -49,6 +54,12 @@ You can create this Daemonset with `kubectl`.
 $ kubectl apply -f caching-daemonset.yaml
 ```
 
-The DaemonSet is deployed in the `image-cache` namespace. In the `initContainers` section, we specify the image to be pulled and cached within the cluster, utilizing any executable command that terminates successfully. Additionally, the `pause` container is used to ensure the pod transitions into a Running state without consuming resources or running any processes.
+The DaemonSet is deployed in the `image-cache` namespace. In the `initContainers` section, we specify the image to be
+pulled and cached within the cluster, utilizing any executable command that terminates successfully. Additionally, the
+`pause` container is used to ensure the pod transitions into a Running state without consuming resources or running any
+processes.
 
-When deploying the DaemonSet, after all pre-puller pods are running successfully, you can confirm that the images have been cached across all nodes in the cluster. As the Kubernetes cluster is scaled up or down, the DaemonSet will automatically pull and cache the necessary images on any newly added nodes, ensuring consistent image availability throughout
+When deploying the DaemonSet, after all pre-puller pods are running successfully, you can confirm that the images have
+been cached across all nodes in the cluster. As the Kubernetes cluster is scaled up or down, the DaemonSet will
+automatically pull and cache the necessary images on any newly added nodes, ensuring consistent image availability
+throughout

--- a/source/guides/colocate-workers.md
+++ b/source/guides/colocate-workers.md
@@ -1,10 +1,15 @@
 # Colocate Dask workers on Kubernetes while using nodes with multiple GPUs
 
-To optimize performance when working with nodes that have multiple GPUs, a best practice is to schedule Dask workers in a tightly grouped manner, thereby minimizing communication overhead between worker pods. This guide provides a step-by-step process for adding pod affinities to worker pods ensuring they are scheduled together as much as possible on Google Kubernetes Engine (GKE), but the principles can be adapted for use with other Kubernetes distributions.
+To optimize performance when working with nodes that have multiple GPUs, a best practice is to schedule Dask workers in
+a tightly grouped manner, thereby minimizing communication overhead between worker pods. This guide provides a
+step-by-step process for adding pod affinities to worker pods ensuring they are scheduled together as much as possible
+on Google Kubernetes Engine (GKE), but the principles can be adapted for use with other Kubernetes distributions.
 
 ## Prerequisites
 
-First you'll need to have the [`gcloud` CLI tool](https://cloud.google.com/sdk/gcloud) installed along with [`kubectl`](https://kubernetes.io/docs/tasks/tools/), [`helm`](https://helm.sh/docs/intro/install/), etc for managing Kubernetes.
+First you'll need to have the [`gcloud` CLI tool](https://cloud.google.com/sdk/gcloud) installed along with
+[`kubectl`](https://kubernetes.io/docs/tasks/tools/), [`helm`](https://helm.sh/docs/intro/install/), etc for managing
+Kubernetes.
 
 Ensure you are logged into the `gcloud` CLI.
 
@@ -27,7 +32,8 @@ a2-highgpu-2g, each with two A100 GPUs.
 
 ## Install drivers
 
-Next, [install the NVIDIA drivers](https://cloud.google.com/kubernetes-engine/docs/how-to/gpus#installing_drivers) onto each node.
+Next, [install the NVIDIA drivers](https://cloud.google.com/kubernetes-engine/docs/how-to/gpus#installing_drivers) onto
+each node.
 
 ```console
 $ kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/master/nvidia-driver-installer/cos/daemonset-preloaded-latest.yaml
@@ -54,7 +60,9 @@ After your drivers are installed, you are ready to test your cluster.
 
 ### Installing Dask operator with Helm
 
-The operator has a Helm chart which can be used to manage the installation of the operator. Follow the instructions provided in the [Dask documentation](https://kubernetes.dask.org/en/latest/installing.html#installing-with-helm), or alternatively can be installed via:
+The operator has a Helm chart which can be used to manage the installation of the operator. Follow the instructions
+provided in the [Dask documentation](https://kubernetes.dask.org/en/latest/installing.html#installing-with-helm), or
+alternatively can be installed via:
 
 ```console
 $ helm install --create-namespace -n dask-operator --generate-name --repo https://helm.dask.org dask-kubernetes-operator
@@ -71,7 +79,8 @@ Operator has been installed successfully.
 
 To configure the `DaskCluster` resource to run RAPIDS you need to set a few things:
 
-- The container image must contain RAPIDS, the [official RAPIDS container images](/tools/rapids-docker) are a good choice for this.
+- The container image must contain RAPIDS, the [official RAPIDS container images](/tools/rapids-docker) are a good
+  choice for this.
 - The Dask workers must be configured with one or more NVIDIA GPU resources.
 - The worker command must be set to `dask-cuda-worker`.
 
@@ -169,9 +178,12 @@ $ kubectl apply -f rapids-dask-cluster.yaml
 
 ### Manifest breakdown
 
-Most of this manifest is explained in the [Dask Operator](https://docs.rapids.ai/deployment/stable/tools/kubernetes/dask-operator/#example-using-kubecluster) documentation in the tools section of the RAPIDS documentation.
+Most of this manifest is explained in the [Dask
+Operator](https://docs.rapids.ai/deployment/stable/tools/kubernetes/dask-operator/#example-using-kubecluster)
+documentation in the tools section of the RAPIDS documentation.
 
-The only addition made to the example from the above documentation page is the following section in the worker configuration
+The only addition made to the example from the above documentation page is the following section in the worker
+configuration
 
 ```yaml
 # ...
@@ -190,11 +202,23 @@ podAffinity:
 # ...
 ```
 
-For the Dask Worker pod configuration, we are setting a pod affinity using the name of the node as the topology key. [Pod affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity) in Kubernetes allows you to constrain which nodes the Pod can be scheduled on and allows you to configure a set of workloads that should be co-located in the same defined topology, in this case, preferring to place two worker pods on the same node. This is also intended to be a soft requirement as we are using the `preferredDuringSchedulingIgnoredDuringExecution` type of pod affinity. The Kubernetes scheduler tries to find a node which meets the rule. If a matching node is not available, the Kubernetes scheduler still schedules the pod on any available node. This ensures that you will not face any issues with the Dask cluster even if placing worker pods on nodes already in use is not possible.
+For the Dask Worker pod configuration, we are setting a pod affinity using the name of the node as the topology key.
+[Pod
+affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity)
+in Kubernetes allows you to constrain which nodes the Pod can be scheduled on and allows you to configure a set of
+workloads that should be co-located in the same defined topology, in this case, preferring to place two worker pods on
+the same node. This is also intended to be a soft requirement as we are using the
+`preferredDuringSchedulingIgnoredDuringExecution` type of pod affinity. The Kubernetes scheduler tries to find a node
+which meets the rule. If a matching node is not available, the Kubernetes scheduler still schedules the pod on any
+available node. This ensures that you will not face any issues with the Dask cluster even if placing worker pods on
+nodes already in use is not possible.
 
 ### Accessing your Dask cluster
 
-Once you have created your `DaskCluster` resource we can use `kubectl` to check the status of all the other resources it created for us.
+Once you have created your `DaskCluster` resource we can use `kubectl` to check the status of all the other resources it
+created for us.
+
+<!-- markdownlint-disable -->
 
 ```console
 $ kubectl get all -l dask.org/cluster-name=rapids-dask-cluster -o wide
@@ -207,10 +231,13 @@ NAME                                    TYPE        CLUSTER-IP      EXTERNAL-IP 
 service/rapids-dask-cluster-scheduler   ClusterIP   10.96.231.110   <none>        8786/TCP,8787/TCP   3s    dask.org/cluster-name=rapids-dask-cluster,dask.org/component=scheduler
 ```
 
-Here you can see our scheduler pod and two worker pods along with the scheduler service. The two worker pods are placed in the same node as desired, while the scheduler pod is placed on a different node.
+<!-- markdownlint-enable -->
 
-If you have a Python session running within the Kubernetes cluster (like the [example one on the Kubernetes page](/platforms/kubernetes)) you should be able
-to connect a Dask distributed client directly.
+Here you can see our scheduler pod and two worker pods along with the scheduler service. The two worker pods are placed
+in the same node as desired, while the scheduler pod is placed on a different node.
+
+If you have a Python session running within the Kubernetes cluster (like the [example one on the Kubernetes
+page](/platforms/kubernetes)) you should be able to connect a Dask distributed client directly.
 
 ```python
 from dask.distributed import Client
@@ -218,7 +245,10 @@ from dask.distributed import Client
 client = Client("rapids-dask-cluster-scheduler:8786")
 ```
 
-Alternatively if you are outside of the Kubernetes cluster you can change the `Service` to use [`LoadBalancer`](https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer) or [`NodePort`](https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport) or use `kubectl` to port forward the connection locally.
+Alternatively if you are outside of the Kubernetes cluster you can change the `Service` to use
+[`LoadBalancer`](https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer) or
+[`NodePort`](https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport) or use `kubectl` to port
+forward the connection locally.
 
 ```console
 $ kubectl port-forward svc/rapids-dask-cluster-service 8786:8786
@@ -233,8 +263,11 @@ client = Client("localhost:8786")
 
 ## Example using `KubeCluster`
 
-In addition to creating clusters via `kubectl` you can also do so from Python with {class}`dask_kubernetes.operator.KubeCluster`. This class implements the Dask Cluster Manager interface and under the hood creates and manages the `DaskCluster` resource for you. You can also generate a spec with make_cluster_spec() which KubeCluster uses internally and then modify it with your custom options. We will use this to add node affinity to the scheduler.
-In the following example, the same cluster configuration as the `kubectl` example is used.
+In addition to creating clusters via `kubectl` you can also do so from Python with
+{class}`dask_kubernetes.operator.KubeCluster`. This class implements the Dask Cluster Manager interface and under the
+hood creates and manages the `DaskCluster` resource for you. You can also generate a spec with make_cluster_spec() which
+KubeCluster uses internally and then modify it with your custom options. We will use this to add node affinity to the
+scheduler. In the following example, the same cluster configuration as the `kubectl` example is used.
 
 ```python
 from dask_kubernetes.operator import KubeCluster, make_cluster_spec
@@ -248,7 +281,8 @@ spec = make_cluster_spec(
 )
 ```
 
-To add the node affinity to the worker, you can create a custom dictionary specifying the type of pod affinity and the topology key.
+To add the node affinity to the worker, you can create a custom dictionary specifying the type of pod affinity and the
+topology key.
 
 ```python
 affinity_config = {
@@ -274,14 +308,18 @@ affinity_config = {
 }
 ```
 
-Now you can add this configuration to the spec created in the previous step, and create the Dask cluster using this custom spec.
+Now you can add this configuration to the spec created in the previous step, and create the Dask cluster using this
+custom spec.
 
 ```python
 spec["spec"]["worker"]["spec"]["affinity"] = affinity_config
 cluster = KubeCluster(custom_cluster_spec=spec)
 ```
 
-If we check with `kubectl` we can see the above Python generated the same `DaskCluster` resource as the `kubectl` example above.
+If we check with `kubectl` we can see the above Python generated the same `DaskCluster` resource as the `kubectl`
+example above.
+
+<!-- markdownlint-disable -->
 
 ```console
 $ kubectl get daskclusters
@@ -298,7 +336,11 @@ NAME                                    TYPE        CLUSTER-IP      EXTERNAL-IP 
 service/rapids-dask-cluster-scheduler   ClusterIP   10.96.231.110   <none>        8786/TCP,8787/TCP   3s    dask.org/cluster-name=rapids-dask-cluster,dask.org/component=scheduler
 ```
 
-With this cluster object in Python we can also connect a client to it directly without needing to know the address as Dask will discover that for us. It also automatically sets up port forwarding if you are outside of the Kubernetes cluster.
+<!-- markdownlint-enable -->
+
+With this cluster object in Python we can also connect a client to it directly without needing to know the address as
+Dask will discover that for us. It also automatically sets up port forwarding if you are outside of the Kubernetes
+cluster.
 
 ```python
 from dask.distributed import Client
@@ -319,9 +361,13 @@ cluster.close()
 ```
 
 ```{note}
-By default the `KubeCluster` command registers an exit hook so when the Python process exits the cluster is deleted automatically. You can disable this by setting `KubeCluster(..., shutdown_on_close=False)` when launching the cluster.
+By default the `KubeCluster` command registers an exit hook so when the Python process exits the cluster is deleted
+automatically. You can disable this by setting `KubeCluster(..., shutdown_on_close=False)` when launching the cluster.
 
-This is useful if you have a multi-stage pipeline made up of multiple Python processes and you want your Dask cluster to persist between them.
+This is useful if you have a multi-stage pipeline made up of multiple Python processes and you want your Dask cluster to
+persist between them.
 
-You can also connect a `KubeCluster` object to your existing cluster with `cluster = KubeCluster.from_name(name="rapids-dask")` if you wish to use the cluster or manually call `cluster.close()` in the future.
+You can also connect a `KubeCluster` object to your existing cluster with
+`cluster = KubeCluster.from_name(name="rapids-dask")` if you wish to use the cluster or manually call `cluster.close()`
+in the future.
 ```

--- a/source/guides/l4-gcp.md
+++ b/source/guides/l4-gcp.md
@@ -1,6 +1,9 @@
 # L4 GPUs on a Google Cloud Platform (GCP)
 
-[L4 GPUs](https://www.nvidia.com/en-us/data-center/l4/) are a more energy and computationally efficient option compared to T4 GPUs. L4 GPUs are [generally available on GCP](https://cloud.google.com/blog/products/compute/introducing-g2-vms-with-nvidia-l4-gpus) to run your workflows with RAPIDS.
+[L4 GPUs](https://www.nvidia.com/en-us/data-center/l4/) are a more energy and computationally efficient option compared
+to T4 GPUs. L4 GPUs are [generally available on
+GCP](https://cloud.google.com/blog/products/compute/introducing-g2-vms-with-nvidia-l4-gpus) to run your workflows with
+RAPIDS.
 
 ## Compute Engine Instance
 
@@ -11,7 +14,8 @@ To create a VM instance with an L4 GPU to run RAPIDS:
 1. Open [**Compute Engine**](https://console.cloud.google.com/compute/instances).
 1. Select **Create Instance**.
 1. Under the **Machine configuration** section, select **GPUs** and then select `NVIDIA L4` in the **GPU type** dropdown.
-1. Under the **Boot Disk** section, click **CHANGE** and select `Deep Learning on Linux` in the **Operating System** dropdown.
+1. Under the **Boot Disk** section, click **CHANGE** and select `Deep Learning on Linux` in the **Operating System**
+   dropdown.
 1. It is also recommended to increase the default boot disk size to something like `100GB`.
 1. Once you have customized other attributes of the instance, click **CREATE**.
 
@@ -25,7 +29,8 @@ To access Jupyter and Dask we will need to set up some firewall rules to open up
 2. Select **Firewall** and **Create firewall rule**
 3. Give the rule a name like `rapids` and ensure the network matches the one you selected for the VM.
 4. Add a tag like `rapids` which we will use to assign the rule to our VM.
-5. Set your source IP range. We recommend you restrict this to your own IP address or your corporate network rather than `0.0.0.0/0` which will allow anyone to access your VM.
+5. Set your source IP range. We recommend you restrict this to your own IP address or your corporate network rather than
+   `0.0.0.0/0` which will allow anyone to access your VM.
 6. Under **Protocols and ports** allow TCP connections on ports `22,8786,8787,8888`.
 
 #### Assign it to the VM
@@ -44,16 +49,20 @@ Next we need to connect to the VM.
 
 ### Install CUDA and NVIDIA Container Toolkit
 
-Since [GCP recommends CUDA 12](https://cloud.google.com/compute/docs/gpus/install-drivers-gpu#no-secure-boot) on L4 VM, we will be upgrading CUDA.
+Since [GCP recommends CUDA 12](https://cloud.google.com/compute/docs/gpus/install-drivers-gpu#no-secure-boot) on L4 VM,
+we will be upgrading CUDA.
 
-1. [Install CUDA Toolkit 12](https://developer.nvidia.com/cuda-downloads) in your VM and accept the default prompts with the following commands.
+1. [Install CUDA Toolkit 12](https://developer.nvidia.com/cuda-downloads) in your VM and accept the default prompts with
+   the following commands.
 
 ```bash
 $ wget https://developer.download.nvidia.com/compute/cuda/12.1.1/local_installers/cuda_12.1.1_530.30.02_linux.run
 $ sudo sh cuda_12.1.1_530.30.02_linux.run
 ```
 
-1. [Install NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#setting-up-nvidia-container-toolkit) with the following commands.
+1. [Install NVIDIA Container
+   Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#setting-up-nvidia-container-toolkit)
+   with the following commands.
 
 ```bash
 $ sudo apt-get update
@@ -76,7 +85,8 @@ $ sudo systemctl restart docker
 
 ### Clean up
 
-Once you are finished head back to the [Deployments](https://console.cloud.google.com/compute/instances) page and delete the instance you created.
+Once you are finished head back to the [Deployments](https://console.cloud.google.com/compute/instances) page and delete
+the instance you created.
 
 ```{relatedexamples}
 

--- a/source/guides/mig.md
+++ b/source/guides/mig.md
@@ -1,20 +1,41 @@
 # Multi-Instance GPU (MIG)
 
-[Multi-Instance GPU](https://www.nvidia.com/en-us/technologies/multi-instance-gpu/) is a technology that allows partitioning a single GPU into multiple instances, making each one seem as a completely independent GPU. Each instance then receives a certain slice of the GPU computational resources and a pre-defined block of memory that is detached from the other instances by on-chip protections.
+[Multi-Instance GPU](https://www.nvidia.com/en-us/technologies/multi-instance-gpu/) is a technology that allows
+partitioning a single GPU into multiple instances, making each one seem as a completely independent GPU. Each instance
+then receives a certain slice of the GPU computational resources and a pre-defined block of memory that is detached from
+the other instances by on-chip protections.
 
-Due to the protection layer to make MIG secure, certain limitations exist. One such limitation that is generally important for HPC applications is the lack of support for [CUDA Inter-Process Communication (IPC)](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#interprocess-communication), which enables transfers over NVLink and NVSwitch to greatly speed up communication between physical GPUs. When using MIG, [NVLink and NVSwitch](https://www.nvidia.com/en-us/data-center/nvlink/) are thus completely unavailable, forcing the application to take a more expensive communication channel via the system (CPU) memory.
+Due to the protection layer to make MIG secure, certain limitations exist. One such limitation that is generally
+important for HPC applications is the lack of support for [CUDA Inter-Process Communication
+(IPC)](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#interprocess-communication), which enables
+transfers over NVLink and NVSwitch to greatly speed up communication between physical GPUs. When using MIG, [NVLink and
+NVSwitch](https://www.nvidia.com/en-us/data-center/nvlink/) are thus completely unavailable, forcing the application to
+take a more expensive communication channel via the system (CPU) memory.
 
-Given limitations in communication capability, we advise users to first understand the tradeoffs that have to be made when attempting to setup a cluster of MIG instances. While the partitioning could be beneficial to certain applications that need only a certain amount of compute capability, communication bottlenecks may be a problem and thus need to be thought of carefully.
+Given limitations in communication capability, we advise users to first understand the tradeoffs that have to be made
+when attempting to setup a cluster of MIG instances. While the partitioning could be beneficial to certain applications
+that need only a certain amount of compute capability, communication bottlenecks may be a problem and thus need to be
+thought of carefully.
 
 ## Dask Cluster
 
-Dask clusters of MIG instances are supported via Dask-CUDA as long as all MIG instances are identical with respect to memory. Much like a cluster of physical GPUs, mixing GPUs with different memory sizes is generally not a good idea as Dask may not be able to balance work correctly and eventually could lead to more frequent out-of-memory errors.
+Dask clusters of MIG instances are supported via Dask-CUDA as long as all MIG instances are identical with respect to
+memory. Much like a cluster of physical GPUs, mixing GPUs with different memory sizes is generally not a good idea as
+Dask may not be able to balance work correctly and eventually could lead to more frequent out-of-memory errors.
 
-For example, partitioning two GPUs into 7 x 10GB instances each and setting up a cluster with all 14 instances should be ok. However, partitioning one of the GPUs into 7 x 10GB instances and another with 3 x 20GB should be avoided.
+For example, partitioning two GPUs into 7 x 10GB instances each and setting up a cluster with all 14 instances should be
+ok. However, partitioning one of the GPUs into 7 x 10GB instances and another with 3 x 20GB should be avoided.
 
-Unlike for a system composed of unpartitioned GPUs, Dask-CUDA cannot automatically infer the GPUs to be utilized for the cluster. In a MIG setup, the user is then required to specify the GPU instances to be used by the cluster. This is achieved by specifying either the `CUDA_VISIBLE_DEVICES` environment variable for either {class}`dask_cuda.LocalCUDACluster` or `dask-cuda-worker`, or the homonymous argument for {class}`dask_cuda.LocalCUDACluster`.
+Unlike for a system composed of unpartitioned GPUs, Dask-CUDA cannot automatically infer the GPUs to be utilized for the
+cluster. In a MIG setup, the user is then required to specify the GPU instances to be used by the cluster. This is
+achieved by specifying either the `CUDA_VISIBLE_DEVICES` environment variable for either
+{class}`dask_cuda.LocalCUDACluster` or `dask-cuda-worker`, or the homonymous argument for
+{class}`dask_cuda.LocalCUDACluster`.
 
-Physical GPUs can be addressed by their indices `[0..N)` (where `N` is the total number of GPUs installed) or by its name composed of the `GPU-` prefix followed by its UUID. MIG instances have no indices and can only be addressed by their names, composed of the `MIG-` prefix followed by its UUID. The name of a MIG instance will the look similar to: `MIG-41b3359c-e721-56e5-8009-12e5797ed514`.
+Physical GPUs can be addressed by their indices `[0..N)` (where `N` is the total number of GPUs installed) or by its
+name composed of the `GPU-` prefix followed by its UUID. MIG instances have no indices and can only be addressed by
+their names, composed of the `MIG-` prefix followed by its UUID. The name of a MIG instance will the look similar to:
+`MIG-41b3359c-e721-56e5-8009-12e5797ed514`.
 
 ### Determine MIG Names
 
@@ -28,9 +49,15 @@ GPU 0: NVIDIA A100-PCIE-40GB (UUID: GPU-84fd49f2-48ad-50e8-9f2e-3bf0dfd47ccb)
   MIG 2g.10gb     Device  2: (UUID: MIG-c6e2bae8-46d4-5a7e-9a68-c6cf1f680ba0)
 ```
 
-In the example case above the system has one NVIDIA A100 with 3 x 10GB MIG instances. In the next sections we will see how to use the instance names to startup a Dask cluster composed of MIG GPUs. Please note that once a GPU is partitioned, the physical GPU (named `GPU-84fd49f2-48ad-50e8-9f2e-3bf0dfd47ccb` above) is inaccessible for CUDA compute and cannot be used as part of a Dask cluster.
+In the example case above the system has one NVIDIA A100 with 3 x 10GB MIG instances. In the next sections we will see
+how to use the instance names to startup a Dask cluster composed of MIG GPUs. Please note that once a GPU is
+partitioned, the physical GPU (named `GPU-84fd49f2-48ad-50e8-9f2e-3bf0dfd47ccb` above) is inaccessible for CUDA compute
+and cannot be used as part of a Dask cluster.
 
-Alternatively, MIG instance names can be obtained programmatically using [NVML](https://developer.nvidia.com/nvidia-management-library-nvml) or [PyNVML](https://pypi.org/project/nvidia-ml-py/). Please refer to the [NVML API](https://docs.nvidia.com/deploy/nvml-api/) to write appropriate utilities for that purpose.
+Alternatively, MIG instance names can be obtained programmatically using
+[NVML](https://developer.nvidia.com/nvidia-management-library-nvml) or [PyNVML](https://pypi.org/project/nvidia-ml-py/).
+Please refer to the [NVML API](https://docs.nvidia.com/deploy/nvml-api/) to write appropriate utilities for that
+purpose.
 
 ### LocalCUDACluster
 
@@ -63,17 +90,26 @@ Suppose you have 3 MIG instances on the local system:
 - `MIG-65b79fff-6d3c-5490-a288-b31ec705f310`
 - `MIG-c6e2bae8-46d4-5a7e-9a68-c6cf1f680ba0`
 
-To start a `dask-cuda-worker` that the address to the scheduler is located in the `scheduler.json` file, the user would run the following:
+To start a `dask-cuda-worker` that the address to the scheduler is located in the `scheduler.json` file, the user would
+run the following:
+
+<!-- markdownlint-disable -->
 
 ```bash
 CUDA_VISIBLE_DEVICES="MIG-41b3359c-e721-56e5-8009-12e5797ed514,MIG-65b79fff-6d3c-5490-a288-b31ec705f310,MIG-c6e2bae8-46d4-5a7e-9a68-c6cf1f680ba0" dask-cuda-worker scheduler.json # --other-arguments
 ```
 
-Please note that in the example above we created 3 Dask-CUDA workers on one node, for a multi-node cluster, the correct MIG names need to be specified, and they will always be different for each host.
+<!-- markdownlint-enable -->
+
+Please note that in the example above we created 3 Dask-CUDA workers on one node, for a multi-node cluster, the correct
+MIG names need to be specified, and they will always be different for each host.
 
 ## XGBoost with Dask Cluster
 
-Currently [XGBoost](https://www.nvidia.com/en-us/glossary/data-science/xgboost/) only exposes support for GPU communication via NCCL, which does not support MIG. For this reason, A Dask cluster that utilizes XGBoost would have to utilize TCP instead for all communications which will likely cause in considerable performance degradation. Therefore, using XGBoost with MIG is not recommended.
+Currently [XGBoost](https://www.nvidia.com/en-us/glossary/data-science/xgboost/) only exposes support for GPU
+communication via NCCL, which does not support MIG. For this reason, A Dask cluster that utilizes XGBoost would have to
+utilize TCP instead for all communications which will likely cause in considerable performance degradation. Therefore,
+using XGBoost with MIG is not recommended.
 
 ```{relatedexamples}
 

--- a/source/guides/scheduler-gpu-requirements.md
+++ b/source/guides/scheduler-gpu-requirements.md
@@ -1,39 +1,59 @@
 # Does the Dask scheduler need a GPU?
 
-A common question from users deploying Dask clusters is whether the scheduler has different minimum requirements to the workers. This question is compounded when using RAPIDS and GPUs.
+A common question from users deploying Dask clusters is whether the scheduler has different minimum requirements to the
+workers. This question is compounded when using RAPIDS and GPUs.
 
 ```{warning}
 This guide outlines our current advice on scheduler hardware requirements, but this may be subject to change.
 ```
 
-**TLDR; It is strongly suggested that your Dask scheduler has matching hardware/software capabilities to the other components in your cluster.**
+**TLDR; It is strongly suggested that your Dask scheduler has matching hardware/software capabilities to the other
+components in your cluster.**
 
-Therefore, if your workers have GPUs and the RAPIDS libraries installed we recommend that your scheduler does too. However the GPU attached to your scheduler doesn't need to be as powerful as the GPUs on your workers, as long as it has the same capabilities and driver/CUDA versions.
+Therefore, if your workers have GPUs and the RAPIDS libraries installed we recommend that your scheduler does too.
+However the GPU attached to your scheduler doesn't need to be as powerful as the GPUs on your workers, as long as it has
+the same capabilities and driver/CUDA versions.
 
 ## What does the scheduler use a GPU for?
 
-The Dask client generates a task graph of operations that it wants to be performed and serializes any data that needs to be sent to the workers. The scheduler handles allocating those tasks to the various Dask workers and passes serialized data back and forth. The workers deserialize the data, perform calculations, serialize the result and pass it back.
+The Dask client generates a task graph of operations that it wants to be performed and serializes any data that needs to
+be sent to the workers. The scheduler handles allocating those tasks to the various Dask workers and passes serialized
+data back and forth. The workers deserialize the data, perform calculations, serialize the result and pass it back.
 
-This can lead users to logically ask if the scheduler needs the same capabilities as the workers/client. It doesn't handle the actual data or do any of the user calculations, it just decides where work should go.
+This can lead users to logically ask if the scheduler needs the same capabilities as the workers/client. It doesn't
+handle the actual data or do any of the user calculations, it just decides where work should go.
 
-Taking this even further you could even ask "Does the Dask scheduler even need to be written in Python?". Some folks even [experimented with a Rust implementation of the scheduler](https://github.com/It4innovations/rsds) a couple of years ago.
+Taking this even further you could even ask "Does the Dask scheduler even need to be written in Python?". Some folks
+even [experimented with a Rust implementation of the scheduler](https://github.com/It4innovations/rsds) a couple of
+years ago.
 
 There are two primary reasons why we recommend that the scheduler has the same capabilities:
 
 - There are edge cases where the scheduler does deserialize data.
 - Some scheduler optimizations require high-level graphs to be pickled on the client and unpickled on the scheduler.
 
-If your workload doesn't trigger any edge-cases and you're not using the high-level graph optimizations then you could likely get away with not having a GPU. But it is likely you will run into problems eventually and the failure-modes will be potentially hard to debug.
+If your workload doesn't trigger any edge-cases and you're not using the high-level graph optimizations then you could
+likely get away with not having a GPU. But it is likely you will run into problems eventually and the failure-modes will
+be potentially hard to debug.
 
 ### Known edge cases
 
-When calling [`client.submit`](https://docs.dask.org/en/latest/futures.html#distributed.Client.submit) and passing data directly to a function the whole graph is serialized and sent to the scheduler. In order for the scheduler to figure out what to do with it the graph is deserialized. If the data uses GPUs this can cause the scheduler to import RAPIDS libraries, attempt to instantiate a CUDA context and populate the data into GPU memory. If those libraries are missing and/or there are no GPUs this will cause the scheduler to fail.
+When calling [`client.submit`](https://docs.dask.org/en/latest/futures.html#distributed.Client.submit) and passing data
+directly to a function the whole graph is serialized and sent to the scheduler. In order for the scheduler to figure out
+what to do with it the graph is deserialized. If the data uses GPUs this can cause the scheduler to import RAPIDS
+libraries, attempt to instantiate a CUDA context and populate the data into GPU memory. If those libraries are missing
+and/or there are no GPUs this will cause the scheduler to fail.
 
-Many Dask collections also have a meta object which represents the overall collection but without any data. For example a Dask Dataframe has a meta Pandas Dataframe which has the same meta properties and is used during scheduling. If the underlying data is instead a cuDF Dataframe then the meta object will be too, which is deserialized on the scheduler.
+Many Dask collections also have a meta object which represents the overall collection but without any data. For example
+a Dask Dataframe has a meta Pandas Dataframe which has the same meta properties and is used during scheduling. If the
+underlying data is instead a cuDF Dataframe then the meta object will be too, which is deserialized on the scheduler.
 
 ### Example failure modes
 
-When using the default TCP communication protocol, the scheduler generally does _not_ inspect data communicated between clients and workers, so many workflows will not provoke failure. For example, suppose we set up a Dask cluster and do not provide the scheduler with a GPU. The following simple computation with [CuPy](https://cupy.dev)-backed Dask arrays completes successfully
+When using the default TCP communication protocol, the scheduler generally does _not_ inspect data communicated between
+clients and workers, so many workflows will not provoke failure. For example, suppose we set up a Dask cluster and do
+not provide the scheduler with a GPU. The following simple computation with [CuPy](https://cupy.dev)-backed Dask arrays
+completes successfully
 
 ```python
 import cupy
@@ -63,7 +83,14 @@ $ python test.py
 ...
 ```
 
-In contrast, if you provision an [Infiniband-enabled system](/guides/azure/infiniband.md) and wish to take advantage of the high-performance network, you will want to use the [UCX](https://openucx.org/) protocol, rather than TCP. Using such a setup without a GPU on the scheduler will not succeed. When the client or workers communicate with the scheduler, any GPU-allocated buffers will be sent directly between GPUs (avoiding a roundtrip to host memory). This is more efficient, but will not succeed if the scheduler does not _have_ a GPU. Running the same example from above, but this time using UCX we obtain an error:
+In contrast, if you provision an [Infiniband-enabled system](/guides/azure/infiniband.md) and wish to take advantage of
+the high-performance network, you will want to use the [UCX](https://openucx.org/) protocol, rather than TCP. Using such
+a setup without a GPU on the scheduler will not succeed. When the client or workers communicate with the scheduler, any
+GPU-allocated buffers will be sent directly between GPUs (avoiding a roundtrip to host memory). This is more efficient,
+but will not succeed if the scheduler does not _have_ a GPU. Running the same example from above, but this time using
+UCX we obtain an error:
+
+<!-- markdownlint-disable -->
 
 ```sh
 $ CUDA_VISIBLE_DEVICES="" dask scheduler --protocol ucx --scheduler-file scheduler.json  &
@@ -173,7 +200,11 @@ RuntimeError: CUDA error at: .../rmm/include/rmm/cuda_device.hpp:56: cudaErrorNo
 ...
 ```
 
-The critical error comes from [RMM](https://docs.rapids.ai/api/rmm/~~~rapids_api_docs_version~~~/), we're attempting to allocate a [`DeviceBuffer`](https://docs.rapids.ai/api/rmm/~~~rapids_api_docs_version~~~/basics.html#devicebuffers) on the scheduler, but there is no GPU available to do so:
+<!-- markdownlint-enable -->
+
+The critical error comes from [RMM](https://docs.rapids.ai/api/rmm/~~~rapids_api_docs_version~~~/), we're attempting to
+allocate a [`DeviceBuffer`](https://docs.rapids.ai/api/rmm/~~~rapids_api_docs_version~~~/basics.html#devicebuffers) on
+the scheduler, but there is no GPU available to do so:
 
 ```pytb
   File ".../distributed/distributed/comm/ucx.py", line 171, in device_array
@@ -184,14 +215,28 @@ RuntimeError: CUDA error at: .../rmm/include/rmm/cuda_device.hpp:56: cudaErrorNo
 
 ### Scheduler optimizations and High-Level graphs
 
-The Dask community is actively working on implementing high-level graphs which will both speed up client -> scheduler communication and allow the scheduler to make advanced optimizations such as predicate pushdown.
+The Dask community is actively working on implementing high-level graphs which will both speed up client -> scheduler
+communication and allow the scheduler to make advanced optimizations such as predicate pushdown.
 
-Much effort has been put into using existing serialization strategies to communicate the HLG but this has proven prohibitively difficult to implement. The current plan is to simplify HighLevelGraph/Layer so that the entire HLG can be pickled on the client, sent to the scheduler as a single binary blob, and then unpickled/materialized (HLG->dict) on the scheduler. The problem with this new plan is that the pickle/un-pickle convention will require the scheduler to have the same environment as the client. If any Layer logic also requires a device allocation, then this approach also requires the scheduler to have access to a GPU.
+Much effort has been put into using existing serialization strategies to communicate the HLG but this has proven
+prohibitively difficult to implement. The current plan is to simplify HighLevelGraph/Layer so that the entire HLG can be
+pickled on the client, sent to the scheduler as a single binary blob, and then unpickled/materialized (HLG->dict) on the
+scheduler. The problem with this new plan is that the pickle/un-pickle convention will require the scheduler to have the
+same environment as the client. If any Layer logic also requires a device allocation, then this approach also requires
+the scheduler to have access to a GPU.
 
 ## So what are the minimum requirements of the scheduler?
 
-From a software perspective we recommend that the Python environment on the client, scheduler and workers all match. Given that the user is expected to ensure the worker has the same environment as the client it is not much of a burden to ensure the scheduler also has the same environment.
+From a software perspective we recommend that the Python environment on the client, scheduler and workers all match.
+Given that the user is expected to ensure the worker has the same environment as the client it is not much of a burden
+to ensure the scheduler also has the same environment.
 
-From a hardware perspective we recommend that the scheduler has the same capabilities, but not necessarily the same quantity of resource. Therefore if the workers have one or more GPUs we recommend that the scheduler has access to one GPU with matching NVIDIA driver and CUDA versions. In a large multi-node cluster deployment on a cloud platform this may mean the workers are launched on VMs with 8 GPUs and the scheduler is launched on a smaller VM with one GPU. You could also select a less powerful GPU such as those intended for inferencing for your scheduler like a T4, provided it has the same CUDA capabilities, NVIDIA driver version and CUDA/CUDA Toolkit version.
+From a hardware perspective we recommend that the scheduler has the same capabilities, but not necessarily the same
+quantity of resource. Therefore if the workers have one or more GPUs we recommend that the scheduler has access to one
+GPU with matching NVIDIA driver and CUDA versions. In a large multi-node cluster deployment on a cloud platform this may
+mean the workers are launched on VMs with 8 GPUs and the scheduler is launched on a smaller VM with one GPU. You could
+also select a less powerful GPU such as those intended for inferencing for your scheduler like a T4, provided it has the
+same CUDA capabilities, NVIDIA driver version and CUDA/CUDA Toolkit version.
 
-This balance means we can guarantee things function as intended, but reduces cost because placing the scheduler on an 8 GPU node would be a waste of resources.
+This balance means we can guarantee things function as intended, but reduces cost because placing the scheduler on an 8
+GPU node would be a waste of resources.

--- a/source/hpc.md
+++ b/source/hpc.md
@@ -4,21 +4,26 @@ review_priority: "index"
 
 # HPC
 
-RAPIDS works extremely well in traditional HPC (High Performance Computing) environments where GPUs are often co-located with accelerated networking hardware such as InfiniBand. Deploying on HPC often means using queue management systems such as SLURM, LSF, PBS, etc.
+RAPIDS works extremely well in traditional HPC (High Performance Computing) environments where GPUs are often co-located
+with accelerated networking hardware such as InfiniBand. Deploying on HPC often means using queue management systems
+such as SLURM, LSF, PBS, etc.
 
 ## SLURM
 
 ```{warning}
-This is a legacy page and may contain outdated information. We are working hard to update our documentation with the latest and greatest information, thank you for bearing with us.
+This is a legacy page and may contain outdated information. We are working hard to update our documentation with the
+latest and greatest information, thank you for bearing with us.
 ```
 
-If you are unfamiliar with SLURM or need a refresher, we recommend the [quickstart guide](https://slurm.schedmd.com/quickstart.html).
-Depending on how your nodes are configured, additional settings may be required such as defining the number of GPUs `(--gpus)` desired or the number of gpus per node `(--gpus-per-node)`.
+If you are unfamiliar with SLURM or need a refresher, we recommend the [quickstart
+guide](https://slurm.schedmd.com/quickstart.html). Depending on how your nodes are configured, additional settings may
+be required such as defining the number of GPUs `(--gpus)` desired or the number of gpus per node `(--gpus-per-node)`.
 In the following example, we assume each allocation runs on a DGX1 with access to all eight GPUs.
 
 ### Start Scheduler
 
-First, start the scheduler with the following SLURM script. This and the following scripts can deployed with `salloc` for interactive usage or `sbatch` for batched run.
+First, start the scheduler with the following SLURM script. This and the following scripts can deployed with `salloc`
+for interactive usage or `sbatch` for batched run.
 
 ```bash
 #!/usr/bin/env bash
@@ -43,16 +48,20 @@ dask-cuda-worker \
     --scheduler-file "$LOCAL_DIRECTORY/dask-scheduler.json"
 ```
 
-Notice that we configure the scheduler to write a `scheduler-file` to a NFS accessible location. This file contains metadata about the scheduler and will
-include the IP address and port for the scheduler. The file will serve as input to the workers informing them what address and port to connect.
+Notice that we configure the scheduler to write a `scheduler-file` to a NFS accessible location. This file contains
+metadata about the scheduler and will include the IP address and port for the scheduler. The file will serve as input to
+the workers informing them what address and port to connect.
 
-The scheduler doesn't need the whole node to itself so we can also start a worker on this node to fill out the unused resources.
+The scheduler doesn't need the whole node to itself so we can also start a worker on this node to fill out the unused
+resources.
 
 ### Start Dask CUDA Workers
 
-Next start the other [dask-cuda workers](https://docs.rapids.ai/api/dask-cuda/~~~rapids_api_docs_version~~~/). Dask-CUDA extends the traditional Dask `Worker` class with specific options and enhancements for GPU environments. Unlike the scheduler and client, the workers script should be scalable and allow the users to tune how many workers are created.
-For example, we can scale the number of nodes to 3: `sbatch/salloc -N3 dask-cuda-worker.script` . In this case, because we have 8 GPUs per node and we have 3 nodes,
-our job will have 24 workers.
+Next start the other [dask-cuda workers](https://docs.rapids.ai/api/dask-cuda/~~~rapids_api_docs_version~~~/). Dask-CUDA
+extends the traditional Dask `Worker` class with specific options and enhancements for GPU environments. Unlike the
+scheduler and client, the workers script should be scalable and allow the users to tune how many workers are created.
+For example, we can scale the number of nodes to 3: `sbatch/salloc -N3 dask-cuda-worker.script` . In this case, because
+we have 8 GPUs per node and we have 3 nodes, our job will have 24 workers.
 
 ```bash
 #!/usr/bin/env bash
@@ -128,5 +137,3 @@ id   name
 
 [6449 rows x 6 columns]
 ```
-
-<br/><br/>

--- a/source/local.md
+++ b/source/local.md
@@ -7,16 +7,20 @@ html_theme.sidebar_secondary.remove: true
 
 ## Conda
 
-Installation instructions for conda are hosted at the [RAPIDS Conda Installation Docs Page](https://docs.rapids.ai/install#conda).
+Installation instructions for conda are hosted at the [RAPIDS Conda Installation Docs
+Page](https://docs.rapids.ai/install#conda).
 
 ## Docker
 
-Installation instructions for Docker are hosted at the [RAPIDS Docker Installation Docs Page](https://docs.rapids.ai/install#docker).
+Installation instructions for Docker are hosted at the [RAPIDS Docker Installation Docs
+Page](https://docs.rapids.ai/install#docker).
 
 ## pip
 
-RAPIDS packages can be installed with pip. See [RAPIDS pip Installation Docs Page](https://docs.rapids.ai/install#pip) for installation instructions and requirements.
+RAPIDS packages can be installed with pip. See [RAPIDS pip Installation Docs Page](https://docs.rapids.ai/install#pip)
+for installation instructions and requirements.
 
 ## WSL2
 
-RAPIDS can be installed on Windows using Windows Subsystem for Linux version 2 (WSL2). See [RAPIDS WSL2 Installation Docs Page](https://docs.rapids.ai/install#wsl2) for installation instructions and requirements.
+RAPIDS can be installed on Windows using Windows Subsystem for Linux version 2 (WSL2). See [RAPIDS WSL2 Installation
+Docs Page](https://docs.rapids.ai/install#wsl2) for installation instructions and requirements.

--- a/source/platforms/coiled.md
+++ b/source/platforms/coiled.md
@@ -1,11 +1,12 @@
 # Coiled
 
-You can deploy RAPIDS on cloud VMs with GPUs using [Coiled](https://www.coiled.io/).
-Coiled is a software platform that manages Cloud VMs on your behalf.
-It manages software environments and can launch Python scripts, Jupyter Notebook servers, Dask clusters or even just individual Python functions.
-Remote machines are booted just in time and shut down when not in use or idle.
+You can deploy RAPIDS on cloud VMs with GPUs using [Coiled](https://www.coiled.io/). Coiled is a software platform that
+manages Cloud VMs on your behalf. It manages software environments and can launch Python scripts, Jupyter Notebook
+servers, Dask clusters or even just individual Python functions. Remote machines are booted just in time and shut down
+when not in use or idle.
 
-By using the [`coiled`](https://anaconda.org/conda-forge/coiled) Python library, you can setup and manage Dask clusters with GPUs and RAPIDs on cloud computing environments such as GCP or AWS.
+By using the [`coiled`](https://anaconda.org/conda-forge/coiled) Python library, you can setup and manage Dask clusters
+with GPUs and RAPIDs on cloud computing environments such as GCP or AWS.
 
 ## Setup
 
@@ -27,31 +28,39 @@ For more information see the [Coiled Getting Started documentation](https://docs
 
 ## Notebook Quickstart
 
-The simplest way to get up and running with RAPIDS on Coiled is to launch a Jupyter notebook server using the RAPIDS notebook container.
+The simplest way to get up and running with RAPIDS on Coiled is to launch a Jupyter notebook server using the RAPIDS
+notebook container.
 
 ```bash
 coiled notebook start --gpu --container {{ rapids_notebooks_container }}
 ```
 
-![Screenshot of Jupyterlab running on Coiled executing some cudf GPU code](../_static/images/platforms/coiled/coiled-jupyter.png)
+![Screenshot of Jupyterlab running on Coiled executing some cudf GPU
+code](../_static/images/platforms/coiled/coiled-jupyter.png)
 
 ## Software Environments
 
-By default when running remote operations Coiled will [attempt to create a copy of your local software environment](https://docs.coiled.io/user_guide/software/sync.html) which can be loaded onto the remote VMs. While this is an excellent feature it's likely that you do not have all of the GPU software libraries you wish to use installed locally. In this case we need to tell Coiled which software environment to use.
+By default when running remote operations Coiled will [attempt to create a copy of your local software
+environment](https://docs.coiled.io/user_guide/software/sync.html) which can be loaded onto the remote VMs. While this
+is an excellent feature it's likely that you do not have all of the GPU software libraries you wish to use installed
+locally. In this case we need to tell Coiled which software environment to use.
 
 ### Container images
 
-All Coiled commands can be passed a container image to use. This container will be pulled onto the remote VM at launch time.
+All Coiled commands can be passed a container image to use. This container will be pulled onto the remote VM at launch
+time.
 
 ```bash
 coiled notebook start --gpu --container {{ rapids_notebooks_container }}
 ```
 
-This is often the most convenient way to try out existing software environments, but is often not the most performant due to the way container images are unpacked.
+This is often the most convenient way to try out existing software environments, but is often not the most performant
+due to the way container images are unpacked.
 
 ### Coiled Software Environments
 
-You can also created Coiled software environments ahead of time. These environments are built and cached on the cloud and can be pulled onto new VMs very quickly.
+You can also created Coiled software environments ahead of time. These environments are built and cached on the cloud
+and can be pulled onto new VMs very quickly.
 
 You can create a RAPIDS software environment using a conda `environment.yaml` file or a pip `requirements.txt` file.
 
@@ -89,20 +98,27 @@ coiled notebook start --gpu --software rapidsai-notebooks
 
 ## CLI Jobs
 
-You can execute a script in a container on an ephemeral VM with [Coiled CLI Jobs](https://docs.coiled.io/user_guide/cli-jobs.html).
+You can execute a script in a container on an ephemeral VM with [Coiled CLI
+Jobs](https://docs.coiled.io/user_guide/cli-jobs.html).
 
 ```bash
 coiled run python my_code.py  # Boots a VM on the cloud, runs the scripts, then shuts down again
 ```
 
-We can use this to run GPU code on a remote environment using the RAPIDS container. You can set the coiled CLI to keep the VM around for a few minutes after execution is complete just in case you want to run it again and reuse the same hardware.
+We can use this to run GPU code on a remote environment using the RAPIDS container. You can set the coiled CLI to keep
+the VM around for a few minutes after execution is complete just in case you want to run it again and reuse the same
+hardware.
 
 ```concole
 $ coiled run --gpu --name rapids-demo --keepalive 5m --container {{ rapids_container }} -- python my_code.py
 ...
 ```
 
-This works very nicely when paired with the cudf.pandas CLI tool. For example we can run `python -m cudf.pandas my_script` to GPU accelerate our Pandas code without having to rewrite anything. For example [this script](https://gist.github.com/jacobtomlinson/2481ecf2e1d2787ae2864a6712eef97b#file-cudf_pandas_coiled_demo-py) processes some open NYC parking data. With `pandas` it takes around a minute, but with `cudf.pandas` it only takes a few seconds.
+This works very nicely when paired with the cudf.pandas CLI tool. For example we can run `python -m cudf.pandas
+my_script` to GPU accelerate our Pandas code without having to rewrite anything. For example [this
+script](https://gist.github.com/jacobtomlinson/2481ecf2e1d2787ae2864a6712eef97b#file-cudf_pandas_coiled_demo-py)
+processes some open NYC parking data. With `pandas` it takes around a minute, but with `cudf.pandas` it only takes a few
+seconds.
 
 ```console
 $ coiled run --gpu --name rapids-demo --keepalive 5m --container {{ rapids_container }} -- python -m cudf.pandas cudf_pandas_coiled_demo.py
@@ -121,13 +137,16 @@ Calculate violations by day of week took: 1.238 seconds
 
 ## Notebooks
 
-To start an interactive Jupyter notebook session with [Coiled Notebooks](https://docs.coiled.io/user_guide/notebooks.html) run the RAPIDS notebook container via the notebook service.
+To start an interactive Jupyter notebook session with [Coiled
+Notebooks](https://docs.coiled.io/user_guide/notebooks.html) run the RAPIDS notebook container via the notebook service.
 
 ```bash
 coiled notebook start --gpu --container {{ rapids_notebooks_container }}
 ```
 
-Note that the `--gpu` flag will automatically select a `g4dn.xlarge` instance with a T4 GPU on AWS. You could additionally add the `--vm-type` flag to explicitly choose another machine type with different GPU configuration. For example to choose a machine with 4 L4 GPUs you would run the following.
+Note that the `--gpu` flag will automatically select a `g4dn.xlarge` instance with a T4 GPU on AWS. You could
+additionally add the `--vm-type` flag to explicitly choose another machine type with different GPU configuration. For
+example to choose a machine with 4 L4 GPUs you would run the following.
 
 ```bash
 coiled notebook start --gpu --vm-type g6.24xlarge --container nvcr.io/nvidia/rapidsai/notebooks:24.12-cuda12.5-py3.12
@@ -135,7 +154,8 @@ coiled notebook start --gpu --vm-type g6.24xlarge --container nvcr.io/nvidia/rap
 
 ## Dask Clusters
 
-Coiled’s [managed Dask clusters](https://docs.coiled.io/user_guide/dask.html) can also provision clusters using [dask-cuda](https://docs.rapids.ai/api/dask-cuda/nightly/) to enable using RAPIDS in a distributed way.
+Coiled’s [managed Dask clusters](https://docs.coiled.io/user_guide/dask.html) can also provision clusters using
+[dask-cuda](https://docs.rapids.ai/api/dask-cuda/nightly/) to enable using RAPIDS in a distributed way.
 
 ```python
 cluster = coiled.Cluster(
@@ -148,7 +168,8 @@ cluster = coiled.Cluster(
 )
 ```
 
-Once the cluster has started you can also get the Jupyter URL and navigate to Jupyter Lab running on the Dask Scheduler node.
+Once the cluster has started you can also get the Jupyter URL and navigate to Jupyter Lab running on the Dask Scheduler
+node.
 
 ```python
 >>> print(cluster.jupyter_link)
@@ -166,9 +187,11 @@ client = Client()
 client
 ```
 
-![Screenshot of Jupyter Lab running on a Coiled Dask Cluster with GPUs](../_static/images/platforms/coiled/jupyter-on-coiled.png)
+![Screenshot of Jupyter Lab running on a Coiled Dask Cluster with
+GPUs](../_static/images/platforms/coiled/jupyter-on-coiled.png)
 
-From this Jupyter session we can see that our notebook server has a GPU and we can connect to the Dask cluster with no configuration and see all the Dask Workers have GPUs too.
+From this Jupyter session we can see that our notebook server has a GPU and we can connect to the Dask cluster with no
+configuration and see all the Dask Workers have GPUs too.
 
 ```{relatedexamples}
 

--- a/source/platforms/colab.md
+++ b/source/platforms/colab.md
@@ -6,14 +6,19 @@ review_priority: "p0"
 
 ## Overview
 
-RAPIDS cuDF is preinstalled on Google Colab and instantly accelerates Pandas with zero code changes. [You can quickly get started with our tutorial notebook](https://nvda.ws/rapids-cudf). This guide is applicable for users who want to utilize the full suite of the RAPIDS libraries for their workflows. It is broken into two sections:
+RAPIDS cuDF is preinstalled on Google Colab and instantly accelerates Pandas with zero code changes. [You can quickly
+get started with our tutorial notebook](https://nvda.ws/rapids-cudf). This guide is applicable for users who want to
+utilize the full suite of the RAPIDS libraries for their workflows. It is broken into two sections:
 
 1. [RAPIDS Quick Install](colab-quick) - applicable for most users and quickly installs all the RAPIDS Stable packages.
-2. [RAPIDS Custom Setup Instructions](colab-custom) - step by step set up instructions covering the **must haves** for when a user needs to adapt instance to their workflows.
+2. [RAPIDS Custom Setup Instructions](colab-custom) - step by step set up instructions covering the **must haves** for
+   when a user needs to adapt instance to their workflows.
 
-In both sections, we will be installing RAPIDS on colab using pip. The pip installation allows users to install cuDF, cuML, cuGraph, cuXfilter, and cuSpatial stable versions in a few minutes.
+In both sections, we will be installing RAPIDS on colab using pip. The pip installation allows users to install cuDF,
+cuML, cuGraph, cuXfilter, and cuSpatial stable versions in a few minutes.
 
-RAPIDS install on Colab strives to be an "always working" solution, and sometimes will **pin** RAPIDS versions to ensure compatibility.
+RAPIDS install on Colab strives to be an "always working" solution, and sometimes will **pin** RAPIDS versions to ensure
+compatibility.
 
 (colab-quick)=
 
@@ -39,7 +44,8 @@ Please follow the links below to our install templates:
 
 ### 1. Launch notebook
 
-To get started in [Google Colab](https://colab.research.google.com/), click `File` at the top toolbar to Create new or Upload existing notebook
+To get started in [Google Colab](https://colab.research.google.com/), click `File` at the top toolbar to Create new or
+Upload existing notebook
 
 ### 2. Set the Runtime
 
@@ -53,13 +59,15 @@ Choose GPU for Hardware Accelerator
 
 ### 3. Check GPU type
 
-Check the output of `!nvidia-smi` to make sure you've been allocated a Rapids Compatible GPU ([see the RAPIDS install docs](https://docs.rapids.ai/install/#system-req)).
+Check the output of `!nvidia-smi` to make sure you've been allocated a Rapids Compatible GPU ([see the RAPIDS install
+docs](https://docs.rapids.ai/install/#system-req)).
 
 ![Screenshot of nvidia-smi](../images/googlecolab-output-nvidia-smi.png)
 
 ### 4. Install RAPIDS on Colab
 
-You can install RAPIDS using pip. The script first checks GPU compatibility with RAPIDS, then installs the latest **stable** versions of some core RAPIDS libraries (e.g. cuDF, cuML, cuGraph, and xgboost) using `pip`.
+You can install RAPIDS using pip. The script first checks GPU compatibility with RAPIDS, then installs the latest
+**stable** versions of some core RAPIDS libraries (e.g. cuDF, cuML, cuGraph, and xgboost) using `pip`.
 
 ```bash
 # Colab warns and provides remediation steps if the GPUs is not compatible with RAPIDS.
@@ -86,4 +94,5 @@ gdf
 
 ### 6. Next steps
 
-Try a more thorough example of using cuDF on Google Colab, "10 Minutes to RAPIDS cuDF's pandas accelerator mode (cudf.pandas)" ([Google Colab link](https://nvda.ws/rapids-cudf)).
+Try a more thorough example of using cuDF on Google Colab, "10 Minutes to RAPIDS cuDF's pandas accelerator mode
+(cudf.pandas)" ([Google Colab link](https://nvda.ws/rapids-cudf)).

--- a/source/platforms/databricks.md
+++ b/source/platforms/databricks.md
@@ -7,7 +7,8 @@ review_priority: "p0"
 You can install RAPIDS on Databricks in a few different ways:
 
 1. Accelerate machine learning workflows in a single-node GPU notebook environment
-2. Spark users can install [RAPIDS Accelerator for Apache Spark 3.x on Databricks](https://docs.nvidia.com/spark-rapids/user-guide/latest/getting-started/databricks.html)
+2. Spark users can install [RAPIDS Accelerator for Apache Spark 3.x on
+   Databricks](https://docs.nvidia.com/spark-rapids/user-guide/latest/getting-started/databricks.html)
 3. Install Dask alongside Spark and then use libraries like `dask-cudf` for multi-node workloads
 
 ## Single-node GPU Notebook environment
@@ -16,11 +17,15 @@ You can install RAPIDS on Databricks in a few different ways:
 
 ### Create init-script
 
-To get started, you must first configure an [initialization script](https://docs.databricks.com/en/init-scripts/index.html) to install RAPIDS libraries and all other dependencies for your project.
+To get started, you must first configure an [initialization
+script](https://docs.databricks.com/en/init-scripts/index.html) to install RAPIDS libraries and all other dependencies
+for your project.
 
-Databricks recommends using [cluster-scoped](https://docs.databricks.com/en/init-scripts/cluster-scoped.html) init scripts stored in the workspace files.
+Databricks recommends using [cluster-scoped](https://docs.databricks.com/en/init-scripts/cluster-scoped.html) init
+scripts stored in the workspace files.
 
-Navigate to the top-left **Workspace** tab and click on your **Home** directory then select **Add** > **File** from the menu. Create an `init.sh` script with contents:
+Navigate to the top-left **Workspace** tab and click on your **Home** directory then select **Add** > **File** from the
+menu. Create an `init.sh` script with contents:
 
 ```bash
 #!/bin/bash
@@ -38,18 +43,21 @@ pip install \
 
 ### Launch cluster
 
-To get started, navigate to the **All Purpose Compute** tab of the **Compute** section in Databricks and select **Create Compute**. Name your cluster and choose **"Single node"**.
+To get started, navigate to the **All Purpose Compute** tab of the **Compute** section in Databricks and select **Create
+Compute**. Name your cluster and choose **"Single node"**.
 
 ![Screenshot of the Databricks compute page](../images/databricks-create-compute.png)
 
-In order to launch a GPU node uncheck **Use Photon Acceleration** and select any `15.x` or `16.x` ML runtime with GPU support.
-For example for long-term support releases you could select the `15.4 LTS ML (includes Apache Spark 3.5.0, GPU, Scala 2.12)` runtime version.
+In order to launch a GPU node uncheck **Use Photon Acceleration** and select any `15.x` or `16.x` ML runtime with GPU
+support. For example for long-term support releases you could select the `15.4 LTS ML (includes Apache Spark 3.5.0, GPU,
+Scala 2.12)` runtime version.
 
 The "GPU accelerated" nodes should now be available in the **Node type** dropdown.
 
 ![Screenshot of selecting a g4dn.xlarge node type](../images/databricks-choose-gpu-node.png)
 
-Then expand the **Advanced Options** section, open the **Init Scripts** tab and enter the file path to the init-script in your Workspace directory starting with `/Users/<user-name>/<script-name>.sh` and click **"Add"**.
+Then expand the **Advanced Options** section, open the **Init Scripts** tab and enter the file path to the init-script
+in your Workspace directory starting with `/Users/<user-name>/<script-name>.sh` and click **"Add"**.
 
 ![Screenshot of init script path](../images/databricks-dask-init-script.png)
 
@@ -57,7 +65,8 @@ Select **Create Compute**
 
 ### Test RAPIDS
 
-Once your cluster has started, you can create a new notebook or open an existing one from the `/Workspace` directory then attach it to your running cluster.
+Once your cluster has started, you can create a new notebook or open an existing one from the `/Workspace` directory
+then attach it to your running cluster.
 
 ```python
 import cudf
@@ -72,9 +81,12 @@ gdf
 
 #### Quickstart with cuDF Pandas
 
-RAPIDS recently introduced cuDF’s [pandas accelerator mode](https://rapids.ai/cudf-pandas/) to accelerate existing pandas workflows with zero changes to code.
+RAPIDS recently introduced cuDF’s [pandas accelerator mode](https://rapids.ai/cudf-pandas/) to accelerate existing
+pandas workflows with zero changes to code.
 
-Using `cudf.pandas` in Databricks on a single-node can offer significant performance improvements over traditional pandas when dealing with large datasets; operations are optimized to run on the GPU (cuDF) whenever possible, seamlessly falling back to the CPU (pandas) when necessary, with synchronization happening in the background.
+Using `cudf.pandas` in Databricks on a single-node can offer significant performance improvements over traditional
+pandas when dealing with large datasets; operations are optimized to run on the GPU (cuDF) whenever possible, seamlessly
+falling back to the CPU (pandas) when necessary, with synchronization happening in the background.
 
 Below is a quick example how to load the `cudf.pandas` extension in a Jupyter notebook:
 
@@ -100,17 +112,25 @@ df = pd.read_parquet(
 )
 ```
 
-Upload the [10 Minutes to RAPIDS cuDF Pandas notebook](https://colab.research.google.com/drive/12tCzP94zFG2BRduACucn5Q_OcX1TUKY3) in your single-node Databricks cluster and run through the cells.
+Upload the [10 Minutes to RAPIDS cuDF Pandas
+notebook](https://colab.research.google.com/drive/12tCzP94zFG2BRduACucn5Q_OcX1TUKY3) in your single-node Databricks
+cluster and run through the cells.
 
-**NOTE**: cuDF pandas is open beta and under active development. You can [learn more through the documentation](https://docs.rapids.ai/api/cudf/~~~rapids_api_docs_version~~~/?_gl=1*1oyfbsi*_ga*MTc5NDYzNzYyNC4xNjgzMDc2ODc2*_ga_RKXFW6CM42*MTcwNTU4NDUyNS4yMC4wLjE3MDU1ODQ1MjUuNjAuMC4w) and the [release blog](https://developer.nvidia.com/blog/rapids-cudf-accelerates-pandas-nearly-150x-with-zero-code-changes/).
+**NOTE**: cuDF pandas is open beta and under active development. You can [learn more through the
+documentation](https://docs.rapids.ai/api/cudf/~~~rapids_api_docs_version~~~/?_gl=1*1oyfbsi*_ga*MTc5NDYzNzYyNC4xNjgzMDc2ODc2*_ga_RKXFW6CM42*MTcwNTU4NDUyNS4yMC4wLjE3MDU1ODQ1MjUuNjAuMC4w)
+and the [release
+blog](https://developer.nvidia.com/blog/rapids-cudf-accelerates-pandas-nearly-150x-with-zero-code-changes/).
 
 ## Multi-node Dask cluster
 
-Dask now has a [dask-databricks](https://github.com/jacobtomlinson/dask-databricks) CLI tool (via [`conda`](https://github.com/conda-forge/dask-databricks-feedstock) and [`pip`](https://pypi.org/project/dask-databricks/)) to simplify the Dask cluster startup process within Databricks.
+Dask now has a [dask-databricks](https://github.com/jacobtomlinson/dask-databricks) CLI tool (via
+[`conda`](https://github.com/conda-forge/dask-databricks-feedstock) and
+[`pip`](https://pypi.org/project/dask-databricks/)) to simplify the Dask cluster startup process within Databricks.
 
 ### Install RAPIDS and Dask
 
-[Create the init script](create-init-script) below to install `dask`, `dask-databricks` RAPIDS libraries and all other dependencies for your project.
+[Create the init script](create-init-script) below to install `dask`, `dask-databricks` RAPIDS libraries and all other
+dependencies for your project.
 
 ```bash
 #!/bin/bash
@@ -133,7 +153,8 @@ dask databricks run --cuda
 
 ```
 
-**Note**: By default, the `dask databricks run` command will launch a dask scheduler in the driver node and standard workers on remaining nodes.
+**Note**: By default, the `dask databricks run` command will launch a dask scheduler in the driver node and standard
+workers on remaining nodes.
 
 To launch a dask cluster with GPU workers, you must parse in `--cuda` flag option.
 
@@ -145,15 +166,20 @@ Be sure to select `14.2 (Scala 2.12, Spark 3.5.0)` Standard Runtime as shown bel
 
 ![Screenshot of standard runtime](../images/databricks-standard-runtime.png)
 
-Then expand the **Advanced Options** section and open the **Docker** tab. Select **Use your own Docker container** and enter the image `databricksruntime/gpu-tensorflow:cuda11.8` or `databricksruntime/gpu-pytorch:cuda11.8`.
+Then expand the **Advanced Options** section and open the **Docker** tab. Select **Use your own Docker container** and
+enter the image `databricksruntime/gpu-tensorflow:cuda11.8` or `databricksruntime/gpu-pytorch:cuda11.8`.
 
 ![Screenshot of custom docker container](../images/databricks-custom-container.png)
 
-Configure the path to your init script in the **Init Scripts** tab. Optionally, you can also configure cluster log delivery in the **Logging** tab, which will write the [init script logs](https://docs.databricks.com/en/init-scripts/logs.html) to DBFS in a subdirectory called `dbfs:/cluster-logs/<cluster-id>/init_scripts/`.
+Configure the path to your init script in the **Init Scripts** tab. Optionally, you can also configure cluster log
+delivery in the **Logging** tab, which will write the [init script
+logs](https://docs.databricks.com/en/init-scripts/logs.html) to DBFS in a subdirectory called
+`dbfs:/cluster-logs/<cluster-id>/init_scripts/`.
 
 ![Screenshot of log delivery](../images/databricks-dask-logging.png)
 
-Once you have completed, you should be able to select a "GPU-Accelerated" instance for both **Worker** and **Driver** nodes.
+Once you have completed, you should be able to select a "GPU-Accelerated" instance for both **Worker** and **Driver**
+nodes.
 
 ![Screenshot of driver worker node](../images/databricks-worker-driver-node.png)
 
@@ -171,9 +197,11 @@ client
 
 #### Dashboard
 
-The **[Dask dashboard](https://docs.dask.org/en/latest/dashboard.html)** provides a web-based UI with visualizations and real-time information about the Dask cluster status i.e task progress, resource utilization, etc.
+The **[Dask dashboard](https://docs.dask.org/en/latest/dashboard.html)** provides a web-based UI with visualizations and
+real-time information about the Dask cluster status i.e task progress, resource utilization, etc.
 
-The dashboard server will start up automatically when the scheduler is created, and is hosted on port `8087` by default. To access follow the URL to the dashboard status endpoint within Databricks.
+The dashboard server will start up automatically when the scheduler is created, and is hosted on port `8087` by default.
+To access follow the URL to the dashboard status endpoint within Databricks.
 
 ![Screenshot of dask-client.png](../images/databricks-mnmg-dask-client.png)
 
@@ -192,7 +220,9 @@ df.x.mean().compute()
 
 #### Dask-Databricks example
 
-In your multi-node cluster, upload the [Training XGBoost with Dask RAPIDS in Databricks](https://github.com/rapidsai/deployment/blob/main/source/examples/xgboost-dask-databricks/notebook.ipynb) example in Jupyter notebook and run through the cells.
+In your multi-node cluster, upload the [Training XGBoost with Dask RAPIDS in
+Databricks](https://github.com/rapidsai/deployment/blob/main/source/examples/xgboost-dask-databricks/notebook.ipynb)
+example in Jupyter notebook and run through the cells.
 
 ### Clean up
 

--- a/source/platforms/index.md
+++ b/source/platforms/index.md
@@ -13,7 +13,8 @@ html_theme.sidebar_secondary.remove: true
 :link-type: doc
 NVIDIA AI Workbench
 ^^^
-Run RAPIDS in NVIDIA AI Workbench, GPU workstation setup tool that enables developers to work, manage, and collaborate across heterogeneous platforms.
+Run RAPIDS in NVIDIA AI Workbench, GPU workstation setup tool that enables developers to work, manage, and collaborate
+across heterogeneous platforms.
 
 {bdg}`single-node`
 ````

--- a/source/platforms/kserve.md
+++ b/source/platforms/kserve.md
@@ -1,27 +1,40 @@
 # KServe
 
-[KServe](https://kserve.github.io/website) is a standard model inference platform built for Kubernetes. It provides consistent interface for multiple machine learning frameworks.
-In this page, we will show you how to deploy RAPIDS models using KServe.
+[KServe](https://kserve.github.io/website) is a standard model inference platform built for Kubernetes. It provides
+consistent interface for multiple machine learning frameworks. In this page, we will show you how to deploy RAPIDS
+models using KServe.
 
 ```{note}
-These instructions were tested against KServe v0.10 running on [Kubernetes v1.21](https://kubernetes.io/blog/2021/04/08/kubernetes-1-21-release-announcement/).
+These instructions were tested against KServe v0.10 running on [Kubernetes
+v1.21](https://kubernetes.io/blog/2021/04/08/kubernetes-1-21-release-announcement/).
 ```
 
 ## Setting up Kubernetes cluster with GPU access
 
-First, you should set up a Kubernetes cluster with access to NVIDIA GPUs. Visit [the Cloud Section](/cloud/index) for guidance.
+First, you should set up a Kubernetes cluster with access to NVIDIA GPUs. Visit [the Cloud Section](/cloud/index) for
+guidance.
 
 ## Installing KServe
 
-Visit [Getting Started with KServe](https://kserve.github.io/website/latest/get_started/) to install KServe in your Kubernetes cluster. If you are starting out, we recommend the use of the "Quickstart" script (`quick_install.sh`) provided in the page. On the other hand, if you are setting up a production-grade system, follow direction in [Administration Guide](https://kserve.github.io/website/latest/admin/serverless/serverless) instead.
+Visit [Getting Started with KServe](https://kserve.github.io/website/latest/get_started/) to install KServe in your
+Kubernetes cluster. If you are starting out, we recommend the use of the "Quickstart" script (`quick_install.sh`)
+provided in the page. On the other hand, if you are setting up a production-grade system, follow direction in
+[Administration Guide](https://kserve.github.io/website/latest/admin/serverless/serverless) instead.
 
 ## Setting up First InferenceService
 
-Once KServe is installed, visit [First InferenceService](https://kserve.github.io/website/latest/get_started/first_isvc/) to quickly set up a first inference endpoint. (The example uses the [Support Vector Machine from scikit-learn](https://scikit-learn.org/stable/modules/generated/sklearn.svm.SVC.html) to classify [the Iris dataset](https://scikit-learn.org/stable/auto_examples/datasets/plot_iris_dataset.html).) Follow through all the steps carefully and make sure everything works. In particular, you should be able to submit inference requests using cURL.
+Once KServe is installed, visit [First
+InferenceService](https://kserve.github.io/website/latest/get_started/first_isvc/) to quickly set up a first inference
+endpoint. (The example uses the [Support Vector Machine from
+scikit-learn](https://scikit-learn.org/stable/modules/generated/sklearn.svm.SVC.html) to classify [the Iris
+dataset](https://scikit-learn.org/stable/auto_examples/datasets/plot_iris_dataset.html).) Follow through all the steps
+carefully and make sure everything works. In particular, you should be able to submit inference requests using cURL.
 
 ## Setting up InferenceService with Triton-FIL
 
-[The FIL backend for Triton Inference Server](https://github.com/triton-inference-server/fil_backend) (Triton-FIL in short) is an optimized inference runtime for many kinds of tree-based models including: XGBoost, LightGBM, scikit-learn, and cuML RandomForest. We can use Triton-FIL together with KServe and serve any tree-based models.
+[The FIL backend for Triton Inference Server](https://github.com/triton-inference-server/fil_backend) (Triton-FIL in
+short) is an optimized inference runtime for many kinds of tree-based models including: XGBoost, LightGBM, scikit-learn,
+and cuML RandomForest. We can use Triton-FIL together with KServe and serve any tree-based models.
 
 The following manifest sets up an inference endpoint using Triton-FIL:
 
@@ -170,8 +183,8 @@ clf.fit(X, y)
 clf.convert_to_treelite_model().to_treelite_checkpoint("./checkpoint.tl")
 ```
 
-Rename the checkpoint file to `checkpoint.tl`, as this is convention used by Triton-FIL.
-After moving the model file into the model directory, the directory should look like this:
+Rename the checkpoint file to `checkpoint.tl`, as this is convention used by Triton-FIL. After moving the model file
+into the model directory, the directory should look like this:
 
 ```text
 model-directory/
@@ -183,4 +196,6 @@ model-directory/
 
 ### Configuring Triton-FIL
 
-Triton-FIL offers many configuration options, and we only showed you a few of them. Please visit [FIL Backend Model Configuration](https://github.com/triton-inference-server/fil_backend/blob/main/docs/model_config.md) to check out the rest.
+Triton-FIL offers many configuration options, and we only showed you a few of them. Please visit [FIL Backend Model
+Configuration](https://github.com/triton-inference-server/fil_backend/blob/main/docs/model_config.md) to check out the
+rest.

--- a/source/platforms/kubernetes.md
+++ b/source/platforms/kubernetes.md
@@ -6,7 +6,8 @@ RAPIDS integrates with Kubernetes in many ways depending on your use case.
 
 ## Interactive Notebook
 
-For single-user interactive sessions you can run the [RAPIDS docker image](/tools/rapids-docker) which contains a conda environment with the RAPIDS libraries and Jupyter for interactive use.
+For single-user interactive sessions you can run the [RAPIDS docker image](/tools/rapids-docker) which contains a conda
+environment with the RAPIDS libraries and Jupyter for interactive use.
 
 You can run this directly on Kubernetes as a `Pod` and expose Jupyter via a `Service`. For example:
 
@@ -52,13 +53,16 @@ spec:
 :color: info
 :icon: info
 
-Deploying an interactive single-user notebook can provide a great place to launch further resources. For example you could install `dask-kubernetes` and use the [dask-operator](../tools/kubernetes/dask-operator) to create multi-node Dask clusters from your notebooks.
+Deploying an interactive single-user notebook can provide a great place to launch further resources. For example you
+could install `dask-kubernetes` and use the [dask-operator](../tools/kubernetes/dask-operator) to create multi-node
+Dask clusters from your notebooks.
 
 To do this you'll need to create a couple of extra resources when launching your notebook `Pod`.
 
 ### Service account and role
 
-To be able to interact with the Kubernetes API from within your notebook and create Dask resources you'll need to create a service account with an attached role.
+To be able to interact with the Kubernetes API from within your notebook and create Dask resources you'll need to create
+a service account with an attached role.
 
 ```yaml
 apiVersion: v1
@@ -110,7 +114,11 @@ spec:
 
 ### Proxying the Dask dashboard and other services
 
-The RAPIDS container comes with the [jupyter-server-proxy](https://jupyter-server-proxy.readthedocs.io/en/latest/) plugin preinstalled which you can use to access other services running in your notebook via the Jupyter URL. However, by default [this is restricted to only proxying services running within your Jupyter Pod](https://jupyter-server-proxy.readthedocs.io/en/latest/arbitrary-ports-hosts.html). To access other resources like Dask clusters that have been launched in the Kubernetes cluster we need to configure Jupyter to allow this.
+The RAPIDS container comes with the [jupyter-server-proxy](https://jupyter-server-proxy.readthedocs.io/en/latest/)
+plugin preinstalled which you can use to access other services running in your notebook via the Jupyter URL. However,
+by default [this is restricted to only proxying services running within your Jupyter
+Pod](https://jupyter-server-proxy.readthedocs.io/en/latest/arbitrary-ports-hosts.html). To access other resources like
+Dask clusters that have been launched in the Kubernetes cluster we need to configure Jupyter to allow this.
 
 First we create a `ConfigMap` with our configuration file.
 
@@ -145,7 +153,8 @@ spec:
         name: jupyter-server-proxy-config
 ```
 
-We also might want to configure Dask to know where to look for the Dashboard via the proxied URL. We can set this via an environment variable in our `Pod`.
+We also might want to configure Dask to know where to look for the Dashboard via the proxied URL. We can set this via an
+environment variable in our `Pod`.
 
 ```yaml
 apiVersion: v1
@@ -259,7 +268,10 @@ spec:
 $ kubectl apply -f rapids-notebook.yaml
 ```
 
-This makes Jupyter accessible on port `30002` of your Kubernetes nodes via `NodePort` service. Alternatively you could use a `LoadBalancer` service type [if you have one configured](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/) or a `ClusterIP` and use `kubectl` to port forward the port locally and access it that way.
+This makes Jupyter accessible on port `30002` of your Kubernetes nodes via `NodePort` service. Alternatively you could
+use a `LoadBalancer` service type [if you have one
+configured](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/) or a `ClusterIP`
+and use `kubectl` to port forward the port locally and access it that way.
 
 ```console
 $ kubectl port-forward service/rapids-notebook 8888
@@ -277,25 +289,39 @@ alt: Screenshot of the RAPIDS container running Jupyter showing the nvidia-smi c
 
 ## Dask Operator
 
-[Dask has an operator](https://kubernetes.dask.org/en/latest/operator.html) that empowers users to create Dask clusters as native Kubernetes resources. This is useful for creating, scaling and removing Dask clusters dynamically and in a flexible way. Usually this is used in conjunction with an interactive session such as the [interactive notebook](interactive-notebook) example above or from another service like [KubeFlow Notebooks](/platforms/kubeflow). By dynamically launching Dask clusters configured to use RAPIDS on Kubernetes user's can burst beyond their notebook session to many GPUs spreak across many nodes.
+[Dask has an operator](https://kubernetes.dask.org/en/latest/operator.html) that empowers users to create Dask clusters
+as native Kubernetes resources. This is useful for creating, scaling and removing Dask clusters dynamically and in a
+flexible way. Usually this is used in conjunction with an interactive session such as the [interactive
+notebook](interactive-notebook) example above or from another service like [KubeFlow Notebooks](/platforms/kubeflow). By
+dynamically launching Dask clusters configured to use RAPIDS on Kubernetes user's can burst beyond their notebook
+session to many GPUs spreak across many nodes.
 
 Find out more on the [Dask Operator page](/tools/kubernetes/dask-operator).
 
 ## Helm Chart
 
-Individual users can also install the [Dask Helm Chart](https://helm.dask.org) which provides a `Pod` running Jupyter alongside a Dask cluster consisting of pods running the Dask scheduler and worker components. You can customize this helm chart to run the RAPIDS container images as both the notebook server and Dask cluster components so that everything can benefit from GPU acceleration.
+Individual users can also install the [Dask Helm Chart](https://helm.dask.org) which provides a `Pod` running Jupyter
+alongside a Dask cluster consisting of pods running the Dask scheduler and worker components. You can customize this
+helm chart to run the RAPIDS container images as both the notebook server and Dask cluster components so that everything
+can benefit from GPU acceleration.
 
 Find out more on the [Dask Helm Chart page](/tools/kubernetes/dask-helm-chart).
 
 ## Dask Gateway
 
-Some organisations may want to provide Dask cluster provisioning as a central service where users are abstracted from the underlying platform like Kubernetes. This can be useful for reducing user permissions, limiting resources that users can consume and exposing things in a centralised way. For this you can deploy Dask Gateway which provides a server that users interact with programmatically and in turn launches Dask clusters on Kubernetes and proxies the connection back to the user.
+Some organisations may want to provide Dask cluster provisioning as a central service where users are abstracted from
+the underlying platform like Kubernetes. This can be useful for reducing user permissions, limiting resources that users
+can consume and exposing things in a centralised way. For this you can deploy Dask Gateway which provides a server that
+users interact with programmatically and in turn launches Dask clusters on Kubernetes and proxies the connection back to
+the user.
 
-Users can configure what they want their Dask cluster to look like so it is possible to utilize GPUs and RAPIDS for an accelerated cluster.
+Users can configure what they want their Dask cluster to look like so it is possible to utilize GPUs and RAPIDS for an
+accelerated cluster.
 
 ## KubeFlow
 
-If you are using KubeFlow you can integrate RAPIDS right away by using the RAPIDS container images within notebooks and pipelines and by using the Dask Operator to launch GPU accelerated Dask clusters.
+If you are using KubeFlow you can integrate RAPIDS right away by using the RAPIDS container images within notebooks and
+pipelines and by using the Dask Operator to launch GPU accelerated Dask clusters.
 
 Find out more on the [KubeFlow page](/platforms/kubeflow).
 

--- a/source/platforms/nvidia-ai-workbench.md
+++ b/source/platforms/nvidia-ai-workbench.md
@@ -1,44 +1,60 @@
 # NVIDIA AI Workbench
 
-[NVIDIA AI Workbench](https://www.nvidia.com/en-us/deep-learning-ai/solutions/data-science/workbench/) is a developer toolkit for data science, machine learning, and AI projects. It lets you develop on your laptop/workstation and then easily transition workloads to scalable GPU resources in a data center or the cloud. AI Workbench is free, you can install it in minutes on both local or remote computers, and offers a desktop application as well as a command-line interface (CLI).
+[NVIDIA AI Workbench](https://www.nvidia.com/en-us/deep-learning-ai/solutions/data-science/workbench/) is a developer
+toolkit for data science, machine learning, and AI projects. It lets you develop on your laptop/workstation and then
+easily transition workloads to scalable GPU resources in a data center or the cloud. AI Workbench is free, you can
+install it in minutes on both local or remote computers, and offers a desktop application as well as a command-line
+interface (CLI).
 
 ## Installation
 
 You can install AI Workbench locally, or on a remote computer that you have SSH access to.
 
-Follow the [AI Workbench installation](https://docs.nvidia.com/ai-workbench/user-guide/latest/installation/overview.html) documentation for instructions on installing on different operating systems.
+Follow the [AI Workbench
+installation](https://docs.nvidia.com/ai-workbench/user-guide/latest/installation/overview.html) documentation for
+instructions on installing on different operating systems.
 
 ```{admonition} Local GPU System
 :class: note
 
 If you are working on a system that has an NVIDIA GPU you can use the AI Workbench
-by installing the desktop application and configure Docker if you don't have it installed already. Then you can run notebooks in Python environments with access to your GPU.
+by installing the desktop application and configure Docker if you don't have it installed already. Then you can run
+notebooks in Python environments with access to your GPU.
 
 ```
 
 ```{admonition} Remote GPU System
 :class: note
 
-If you don't have an NVIDIA GPU in your system, but have remote SSH access to a system that does, then you can use AI Workbench to connect to that system. Your code will be executed on the remote system, but files will be synced between your local and remote environments automatically. This allows you to burst from a system without NVIDIA GPUs like a lightweight laptop to a powerful remote AI system.
+If you don't have an NVIDIA GPU in your system, but have remote SSH access to a system that does, then you can use AI
+Workbench to connect to that system. Your code will be executed on the remote system, but files will be synced between
+your local and remote environments automatically. This allows you to burst from a system without NVIDIA GPUs like a
+lightweight laptop to a powerful remote AI system.
 
-To use AI Workbench in this way you need to install the desktop application on your local system and the CLI application on the remote system.
+To use AI Workbench in this way you need to install the desktop application on your local system and the CLI application
+on the remote system.
 ```
 
 ## Configure your system
 
-Once you have installed AI Workbench you can launch the desktop application. On first run it will talk you through installing some dependencies if they aren't available already.
+Once you have installed AI Workbench you can launch the desktop application. On first run it will talk you through
+installing some dependencies if they aren't available already.
 
-Then you will be able to choose between using your local environment or working on a remote system (you can switch between them later very easily).
+Then you will be able to choose between using your local environment or working on a remote system (you can switch
+between them later very easily).
 
-If you wish to configure a remote system click the "Add Remote System" button and enter the configuration information for that system.
+If you wish to configure a remote system click the "Add Remote System" button and enter the configuration information
+for that system.
 
 ![Screenshot of adding a new remote location with a form where you can enter SSH information](../_static/images/platforms/nvidia-ai-workbench/add-remote-system-dialog.png)
 
-Once configured select the system you wish to use. You will then be greeted with a screen where you can create a new project or clone an existing one.
+Once configured select the system you wish to use. You will then be greeted with a screen where you can create a new
+project or clone an existing one.
 
 ![Screenshot of ](../_static/images/platforms/nvidia-ai-workbench/new-project.png)
 
-Select "Start a new project" and give it a name and description. You can also change the default location to store the project files.
+Select "Start a new project" and give it a name and description. You can also change the default location to store the
+project files.
 
 ![Screenshot of the "Start a new project" button](../_static/images/platforms/nvidia-ai-workbench/create-project.png)
 
@@ -46,7 +62,8 @@ Then scroll down and select "RAPIDS with CUDA" from the list of templates.
 
 ![Screenshot of the template selector with "RAPIDS with CUDA" highlighted](../_static/images/platforms/nvidia-ai-workbench/rapids-with-cuda.png)
 
-The new project will then be created. AI Workbench will automatically build a container for this project, this may take a few minutes.
+The new project will then be created. AI Workbench will automatically build a container for this project, this may take
+a few minutes.
 
 ![Screenshot of the AI workbench UI. In the bottom corner the build status says "Building" and the "Open Jupyterlab" button is greyed out](../_static/images/platforms/nvidia-ai-workbench/project-building.png)
 
@@ -60,4 +77,5 @@ Then you can start working with the RAPIDS libraries in your notebooks.
 
 ## Further reading
 
-For more information and to learn more about what you can do with NVIDIA AI Workbench [see the documentation](https://docs.nvidia.com/ai-workbench/user-guide/latest/overview/introduction.html).
+For more information and to learn more about what you can do with NVIDIA AI Workbench [see the
+documentation](https://docs.nvidia.com/ai-workbench/user-guide/latest/overview/introduction.html).

--- a/source/platforms/snowflake.md
+++ b/source/platforms/snowflake.md
@@ -1,15 +1,18 @@
 # Snowflake
 
-You can install RAPIDS on [Snowflake](https://www.snowflake.com) via [Snowpark Container Services](https://docs.snowflake.com/en/developer-guide/snowpark-container-services/overview).
+You can install RAPIDS on [Snowflake](https://www.snowflake.com) via [Snowpark Container
+Services](https://docs.snowflake.com/en/developer-guide/snowpark-container-services/overview).
 
 ```{note}
 The following instructions are an adaptation of the [Introduction to Snowpark
-container Services](https://quickstarts.snowflake.com/guide/intro_to_snowpark_container_services/#0) guide from the Snowflake documentation.
+container Services](https://quickstarts.snowflake.com/guide/intro_to_snowpark_container_services/#0) guide from the
+Snowflake documentation.
 ```
 
 ## Snowflake requirements
 
-- A non-trial Snowflake account in a supported [AWS region](https://docs.snowflake.com/en/developer-guide/snowpark-container-services/overview#available-regions).
+- A non-trial Snowflake account in a supported [AWS
+  region](https://docs.snowflake.com/en/developer-guide/snowpark-container-services/overview#available-regions).
 - A Snowflake account login with a role that has the `ACCOUNTADMIN` role. If not,
   you will need to work with your `ACCOUNTADMIN` to perform the initial account setup.
 - Access to `INSTANCE_FAMILY` with NVIDIA GPUs. For this guide we will use `GPU_NV_S`
@@ -53,8 +56,8 @@ ENCRYPTION = (TYPE='SNOWFLAKE_SSE')
 DIRECTORY = (ENABLE = TRUE);
 ```
 
-Then we proceed to create the external access integration, the compute pool (with
-GPU resources), and the image repository:
+Then we proceed to create the external access integration, the compute pool (with GPU resources), and the image
+repository:
 
 ```sql
 USE ROLE ACCOUNTADMIN;
@@ -163,12 +166,15 @@ USE ROLE CONTAINER_USER_ROLE;
 SHOW IMAGE REPOSITORIES IN SCHEMA CONTAINER_HOL_DB.PUBLIC;
 ```
 
-You will see that the repository url is `org-account.registry.snowflakecomputing.com/container_hol_db/public/image_repo` where `org-account` refers to your organization and account, the `SNOWFLAKE_REGISTRY_HOSTNAME` is the url up to the `.com`. i.e. `org-account.registry.snowflakecomputing.com`
+You will see that the repository url is `org-account.registry.snowflakecomputing.com/container_hol_db/public/image_repo`
+where `org-account` refers to your organization and account, the `SNOWFLAKE_REGISTRY_HOSTNAME` is the url up to the
+`.com`. i.e. `org-account.registry.snowflakecomputing.com`
 
 First we login into the snowflake image-registry via terminal:
 
 ````{note}
-If you have **MFA** activated you will want to allow [client MFA caching] (https://docs.snowflake.com/en/user-guide/security-mfa#using-mfa-token-caching-to-minimize-the-number-of-prompts-during-authentication-optional)
+If you have **MFA** activated you will want to allow [client MFA
+caching] (https://docs.snowflake.com/en/user-guide/security-mfa#using-mfa-token-caching-to-minimize-the-number-of-prompts-during-authentication-optional)
 to reduce the number of prompts that must be acknowledged while connecting and authenticating to Snowflake.
 
 To enable this, you need `ACCOUNTADMIN` system role and in a sql sheet run:
@@ -188,7 +194,8 @@ pip install "snowflake-connector-python[secure-local-storage]"
 snow spcs image-registry login --connection CONTAINER_HOL
 ```
 
-We tag and push the image, make sure you replace the repository url for `org-account.registry.snowflakecomputing.com/container_hol_db/public/image_repo`:
+We tag and push the image, make sure you replace the repository url for
+`org-account.registry.snowflakecomputing.com/container_hol_db/public/image_repo`:
 
 ```bash
 docker tag <local_repository>/rapids-nb-snowflake:latest <repository_url>/rapids-nb-snowflake:dev
@@ -211,7 +218,8 @@ This step will take some time, while this process completes we can continue
 with next step to configure and push the Spec YAML.
 ```
 
-When the `docker push` command completes, you can verify that the image exists in your Snowflake Image Repository by running the following in the Snowflake SQL worksheet
+When the `docker push` command completes, you can verify that the image exists in your Snowflake Image Repository by
+running the following in the Snowflake SQL worksheet
 
 ```{code-block} sql
 :force:
@@ -222,8 +230,10 @@ CALL SYSTEM$REGISTRY_LIST_IMAGES('/CONTAINER_HOL_DB/PUBLIC/IMAGE_REPO');
 
 ## Configure and Push Spec YAML
 
-Snowpark Container Services are defined and configured using YAML files. There
-is support for multiple parameters configurations, refer to then [Snowpark container services specification reference](https://docs.snowflake.com/en/developer-guide/snowpark-container-services/specification-reference) for more information.
+Snowpark Container Services are defined and configured using YAML files. There is support for multiple parameters
+configurations, refer to then [Snowpark container services specification
+reference](https://docs.snowflake.com/en/developer-guide/snowpark-container-services/specification-reference) for more
+information.
 
 Locally, create the following file `rapids-snowpark.yaml`:
 

--- a/source/platforms/snowflake.md
+++ b/source/platforms/snowflake.md
@@ -267,9 +267,9 @@ spec:
       gid: 1000
 ```
 
-Notice that in we mounted the `@volumes/rapids-notebooks` internal stage location
-to our `/home/rapids/notebooks/workspace` directory inside of our running container.
-Anything that is added to this directory will persist.
+Notice that in we mounted the `@volumes/rapids-notebooks` internal stage location to our
+`/home/rapids/notebooks/workspace` directory inside of our running container. Anything that is added to this directory
+will persist.
 
 We use `snow-cli` to push this `yaml` file:
 
@@ -287,9 +287,8 @@ LS @CONTAINER_HOL_DB.PUBLIC.SPECS;
 
 ## Create and Test the Service
 
-Now that we have successfully pushed the image and the spec YAML, we have all
-the components in Snowflake to create our service. We only need a service name,
-a compute pool and the spec file. Run this SQL in the Snowflake worksheet:
+Now that we have successfully pushed the image and the spec YAML, we have all the components in Snowflake to create our
+service. We only need a service name, a compute pool and the spec file. Run this SQL in the Snowflake worksheet:
 
 ```sql
 USE ROLE CONTAINER_USER_ROLE;
@@ -308,16 +307,15 @@ Run the following to verify that the service is successfully running.
 CALL SYSTEM$GET_SERVICE_STATUS('CONTAINER_HOL_DB.PUBLIC.rapids_snowpark_service');
 ```
 
-Since we specified the `jupyter` endpoint to be public, Snowflake will generate
-a url that can be used to access the service via the browser. To get the url,
-run in the SQL snowflake worksheet:
+Since we specified the `jupyter` endpoint to be public, Snowflake will generate a url that can be used to access the
+service via the browser. To get the url, run in the SQL snowflake worksheet:
 
 ```sql
 SHOW ENDPOINTS IN SERVICE RAPIDS_SNOWPARK_SERVICE;
 ```
 
-Copy the jupyter `ingress_url` in the browser. You will see a jupyter lab with a set of
-notebooks to get started with RAPIDS.
+Copy the jupyter `ingress_url` in the browser. You will see a jupyter lab with a set of notebooks to get started with
+RAPIDS.
 
 ```{figure} /images/snowflake_jupyter.png
 ---
@@ -327,8 +325,8 @@ alt: Screenshot of Jupyter Lab with rapids example notebooks directories.
 
 ## Shutdown and Cleanup
 
-If you no longer need the service and the compute pool up and running, we can
-stop the service and suspend the compute pool to avoid incurring in any charges.
+If you no longer need the service and the compute pool up and running, we can stop the service and suspend the compute
+pool to avoid incurring in any charges.
 
 In the Snowflake SQL worksheet run:
 
@@ -338,8 +336,7 @@ ALTER COMPUTE POOL CONTAINER_HOL_POOL STOP ALL;
 ALTER COMPUTE POOL CONTAINER_HOL_POOL SUSPEND;
 ```
 
-If you want to cleanup completely and remove all of the objects created, run the
-following:
+If you want to cleanup completely and remove all of the objects created, run the following:
 
 ```sql
 USE ROLE CONTAINER_USER_ROLE;

--- a/source/tools/dask-cuda.md
+++ b/source/tools/dask-cuda.md
@@ -1,22 +1,29 @@
 # dask-cuda
 
-[Dask-CUDA](https://docs.rapids.ai/api/dask-cuda/~~~rapids_api_docs_version~~~/) is a library extending `LocalCluster` from `dask.distributed` to enable multi-GPU workloads.
+[Dask-CUDA](https://docs.rapids.ai/api/dask-cuda/~~~rapids_api_docs_version~~~/) is a library extending `LocalCluster`
+from `dask.distributed` to enable multi-GPU workloads.
 
 ## LocalCUDACluster
 
-You can use `LocalCUDACluster` to create a cluster of one or more GPUs on your local machine. You can launch a Dask scheduler on LocalCUDACluster to parallelize and distribute your RAPIDS workflows across multiple GPUs on a single node.
+You can use `LocalCUDACluster` to create a cluster of one or more GPUs on your local machine. You can launch a Dask
+scheduler on LocalCUDACluster to parallelize and distribute your RAPIDS workflows across multiple GPUs on a single node.
 
-In addition to enabling multi-GPU computation, `LocalCUDACluster` also provides a simple interface for managing the cluster, such as starting and stopping the cluster, querying the status of the nodes, and monitoring the workload distribution.
+In addition to enabling multi-GPU computation, `LocalCUDACluster` also provides a simple interface for managing the
+cluster, such as starting and stopping the cluster, querying the status of the nodes, and monitoring the workload
+distribution.
 
 ## Pre-requisites
 
-Before running these instructions, ensure you have installed the [`dask`](https://docs.dask.org/en/stable/install.html) and [`dask-cuda`](https://docs.rapids.ai/api/dask-cuda/~~~rapids_api_docs_version~~~/install.html) packages in your local environment.
+Before running these instructions, ensure you have installed the [`dask`](https://docs.dask.org/en/stable/install.html)
+and [`dask-cuda`](https://docs.rapids.ai/api/dask-cuda/~~~rapids_api_docs_version~~~/install.html) packages in your
+local environment.
 
 ## Cluster setup
 
 ### Instantiate a LocalCUDACluster object
 
-The `LocalCUDACluster` class autodetects the GPUs in your system, so if you create it on a machine with two GPUs it will create a cluster with two workers, each of which is responsible for executing tasks on a separate GPU.
+The `LocalCUDACluster` class autodetects the GPUs in your system, so if you create it on a machine with two GPUs it will
+create a cluster with two workers, each of which is responsible for executing tasks on a separate GPU.
 
 ```python
 from dask_cuda import LocalCUDACluster
@@ -25,7 +32,8 @@ from dask.distributed import Client
 cluster = LocalCUDACluster()
 ```
 
-You can also restrict your cluster to use specific GPUs by setting the `CUDA_VISIBLE_DEVICES` environment variable, or as a keyword argument.
+You can also restrict your cluster to use specific GPUs by setting the `CUDA_VISIBLE_DEVICES` environment variable, or
+as a keyword argument.
 
 ```python
 cluster = LocalCUDACluster(
@@ -35,7 +43,8 @@ cluster = LocalCUDACluster(
 
 ### Connecting a Dask client
 
-The Dask scheduler coordinates the execution of tasks, whereas the Dask client is the user-facing interface that submits tasks to the scheduler and monitors their progress.
+The Dask scheduler coordinates the execution of tasks, whereas the Dask client is the user-facing interface that submits
+tasks to the scheduler and monitors their progress.
 
 ```python
 client = Client(cluster)

--- a/source/tools/kubernetes/dask-helm-chart.md
+++ b/source/tools/kubernetes/dask-helm-chart.md
@@ -46,8 +46,8 @@ jupyter:
 
 `[jupyter|scheduler|worker].image.*` is updated with the RAPIDS "runtime" image from the stable release,
 which includes environment necessary to launch run accelerated libraries in RAPIDS, and scaling up and down via dask.
-Note that all scheduler, worker and jupyter pods are required to use the same image.
-This ensures that dask scheduler and worker versions match.
+Note that all scheduler, worker and jupyter pods are required to use the same image. This ensures that dask scheduler
+and worker versions match.
 
 `[jupyter|worker].resources` explicitly requests a GPU for each worker pod and the Jupyter pod, required by many
 accelerated libraries in RAPIDS.

--- a/source/tools/kubernetes/dask-helm-chart.md
+++ b/source/tools/kubernetes/dask-helm-chart.md
@@ -6,11 +6,13 @@ Dask has a [Helm Chart](https://github.com/dask/helm-chart) that creates the fol
 - 1 x Dask scheduler
 - 3 x Dask workers that connect to the scheduler (scalable)
 
-This helm chart can be configured to run RAPIDS by providing GPUs to the Jupyter server and Dask workers and by using container images with the RAPIDS libraries available.
+This helm chart can be configured to run RAPIDS by providing GPUs to the Jupyter server and Dask workers and by using
+container images with the RAPIDS libraries available.
 
 ## Configuring RAPIDS
 
-Built on top of the Dask Helm Chart, `rapids-config.yaml` file contains additional configurations required to setup RAPIDS environment.
+Built on top of the Dask Helm Chart, `rapids-config.yaml` file contains additional configurations required to setup
+RAPIDS environment.
 
 ```yaml
 # rapids-config.yaml
@@ -47,13 +49,16 @@ which includes environment necessary to launch run accelerated libraries in RAPI
 Note that all scheduler, worker and jupyter pods are required to use the same image.
 This ensures that dask scheduler and worker versions match.
 
-`[jupyter|worker].resources` explicitly requests a GPU for each worker pod and the Jupyter pod, required by many accelerated libraries in RAPIDS.
+`[jupyter|worker].resources` explicitly requests a GPU for each worker pod and the Jupyter pod, required by many
+accelerated libraries in RAPIDS.
 
-`worker.dask_worker` is the launch command for dask worker inside worker pod.
-To leverage the GPUs assigned to each Pod the [`dask_cuda_worker`](https://docs.rapids.ai/api/dask-cuda/~~~rapids_api_docs_version~~~/index.html) command is launched in place of the regular `dask_worker`.
+`worker.dask_worker` is the launch command for dask worker inside worker pod. To leverage the GPUs assigned to each Pod
+the [`dask_cuda_worker`](https://docs.rapids.ai/api/dask-cuda/~~~rapids_api_docs_version~~~/index.html) command is
+launched in place of the regular `dask_worker`.
 
-If desired to have a different jupyter notebook password than default, compute the hash for `<your-password>` and update `jupyter.password`.
-You can compute password hash by following the [jupyter notebook guide](https://jupyter-notebook.readthedocs.io/en/stable/public_server.html?highlight=passwd#preparing-a-hashed-password).
+If desired to have a different jupyter notebook password than default, compute the hash for `<your-password>` and update
+`jupyter.password`. You can compute password hash by following the [jupyter notebook
+guide](https://jupyter-notebook.readthedocs.io/en/stable/public_server.html?highlight=passwd#preparing-a-hashed-password).
 
 ### Installing the Helm Chart
 
@@ -93,8 +98,8 @@ Now we can verify that everything is working correctly by running some of the ex
 
 Open the `10 Minutes to cuDF and Dask-cuDF` notebook under `cudf/10-min.ipynb`.
 
-Add a new cell at the top to connect to the Dask cluster. Conveniently, the helm chart preconfigures the scheduler address in client's environment.
-So you do not need to pass any config to the `Client` object.
+Add a new cell at the top to connect to the Dask cluster. Conveniently, the helm chart preconfigures the scheduler
+address in client's environment. So you do not need to pass any config to the `Client` object.
 
 ```python
 from dask.distributed import Client
@@ -107,8 +112,8 @@ By default, we can see 3 workers are created and each has 1 GPU assigned.
 
 ![dask worker](../../_static/daskworker.PNG)
 
-Walk through the examples to validate that the dask cluster is setup correctly, and that GPUs are accessible for the workers.
-Worker metrics can be examined in dask dashboard.
+Walk through the examples to validate that the dask cluster is setup correctly, and that GPUs are accessible for the
+workers. Worker metrics can be examined in dask dashboard.
 
 ![dask worker](../../_static/workingdask.PNG)
 

--- a/source/tools/kubernetes/dask-operator.md
+++ b/source/tools/kubernetes/dask-operator.md
@@ -1,11 +1,12 @@
 # Dask Operator
 
-Many libraries in RAPIDS can leverage Dask to scale out computation onto multiple GPUs and multiple nodes.
-[Dask has an operator for Kubernetes](https://kubernetes.dask.org/en/latest/) which allows you to launch Dask clusters as native Kubernetes resources.
+Many libraries in RAPIDS can leverage Dask to scale out computation onto multiple GPUs and multiple nodes. [Dask has an
+operator for Kubernetes](https://kubernetes.dask.org/en/latest/) which allows you to launch Dask clusters as native
+Kubernetes resources.
 
-With the operator and associated Custom Resource Definitions (CRDs)
-you can create `DaskCluster`, `DaskWorkerGroup` and `DaskJob` resources that describe your Dask components and the operator will
-create the appropriate Kubernetes resources like `Pods` and `Services` to launch the cluster.
+With the operator and associated Custom Resource Definitions (CRDs) you can create `DaskCluster`, `DaskWorkerGroup` and
+`DaskJob` resources that describe your Dask components and the operator will create the appropriate Kubernetes resources
+like `Pods` and `Services` to launch the cluster.
 
 ```{mermaid}
 graph TD
@@ -43,15 +44,18 @@ graph TD
 
 ## Installation
 
-Your Kubernetes cluster must have GPU nodes and have [up to date NVIDIA drivers installed](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/getting-started.html).
+Your Kubernetes cluster must have GPU nodes and have [up to date NVIDIA drivers
+installed](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/getting-started.html).
 
-To install the Dask operator follow the [instructions in the Dask documentation](https://kubernetes.dask.org/en/latest/installing.html).
+To install the Dask operator follow the [instructions in the Dask
+documentation](https://kubernetes.dask.org/en/latest/installing.html).
 
 ## Configuring a RAPIDS `DaskCluster`
 
 To configure the `DaskCluster` resource to run RAPIDS you need to set a few things:
 
-- The container image must contain RAPIDS, the [official RAPIDS container images](/tools/rapids-docker) are a good choice for this.
+- The container image must contain RAPIDS, the [official RAPIDS container images](/tools/rapids-docker) are a good
+  choice for this.
 - The Dask workers must be configured with one or more NVIDIA GPU resources.
 - The worker command must be set to `dask-cuda-worker`.
 
@@ -158,8 +162,9 @@ Then inside the `spec` we have `worker` and `scheduler` sections.
 
 #### Worker
 
-The worker contains a `replicas` option to set how many workers you need and a `spec` that describes what each worker pod should look like.
-The spec is a nested [`Pod` spec](https://kubernetes.io/docs/concepts/workloads/pods/) that the operator will use when creating new `Pod` resources.
+The worker contains a `replicas` option to set how many workers you need and a `spec` that describes what each worker
+pod should look like. The spec is a nested [`Pod` spec](https://kubernetes.io/docs/concepts/workloads/pods/) that the
+operator will use when creating new `Pod` resources.
 
 ```yaml
 # ...
@@ -182,12 +187,13 @@ spec:
     # ...
 ```
 
-Inside our pod spec we are configuring one container that uses the `rapidsai/base` container image.
-It also sets the `args` to start the `dask-cuda-worker` and configures one NVIDIA GPU.
+Inside our pod spec we are configuring one container that uses the `rapidsai/base` container image. It also sets the
+`args` to start the `dask-cuda-worker` and configures one NVIDIA GPU.
 
 #### Scheduler
 
-Next we have a `scheduler` section that also contains a `spec` for the scheduler pod and a `service` which will be used by the operator to create a `Service` resource to expose the scheduler.
+Next we have a `scheduler` section that also contains a `spec` for the scheduler pod and a `service` which will be used
+by the operator to create a `Service` resource to expose the scheduler.
 
 ```yaml
 # ...
@@ -225,14 +231,15 @@ spec:
       # ...
 ```
 
-For the scheduler pod we are also setting the `rapidsai/base` container image, mainly to ensure our Dask versions match between
-the scheduler and workers. We ensure that the `dask-scheduler` command is configured.
+For the scheduler pod we are also setting the `rapidsai/base` container image, mainly to ensure our Dask versions match
+between the scheduler and workers. We ensure that the `dask-scheduler` command is configured.
 
-Then we configure both the Dask communication port on `8786` and the Dask dashboard on `8787` and add some probes so that Kubernetes can monitor
-the health of the scheduler.
+Then we configure both the Dask communication port on `8786` and the Dask dashboard on `8787` and add some probes so
+that Kubernetes can monitor the health of the scheduler.
 
 ```{note}
-The ports must have the `tcp-` and `http-` prefixes if your Kubernetes cluster uses [Istio](https://istio.io/) to ensure the [Envoy proxy](https://www.envoyproxy.io/) doesn't mangle the traffic.
+The ports must have the `tcp-` and `http-` prefixes if your Kubernetes cluster uses [Istio](https://istio.io/) to ensure
+the [Envoy proxy](https://www.envoyproxy.io/) doesn't mangle the traffic.
 ```
 
 Then we configure the `Service`.
@@ -261,14 +268,18 @@ spec:
           targetPort: "http-dashboard"
 ```
 
-This example shows using a `ClusterIP` service which will not expose the Dask cluster outside of Kubernetes. If you prefer you could set this to
-[`LoadBalancer`](https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer) or [`NodePort`](https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport) to make this externally accessible.
+This example shows using a `ClusterIP` service which will not expose the Dask cluster outside of Kubernetes. If you
+prefer you could set this to
+[`LoadBalancer`](https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer) or
+[`NodePort`](https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport) to make this externally
+accessible.
 
 It has a `selector` that matches the scheduler pod and the same ports configured.
 
 ### Accessing your Dask cluster
 
-Once you have created your `DaskCluster` resource we can use `kubectl` to check the status of all the other resources it created for us.
+Once you have created your `DaskCluster` resource we can use `kubectl` to check the status of all the other resources it
+created for us.
 
 ```console
 $ kubectl get all -l dask.org/cluster-name=rapids-dask-cluster
@@ -283,8 +294,8 @@ service/rapids-dask-cluster-service   ClusterIP   10.96.223.217   <none>        
 
 Here you can see our scheduler pod and two worker pods along with the scheduler service.
 
-If you have a Python session running within the Kubernetes cluster (like the [example one on the Kubernetes page](/platforms/kubernetes)) you should be able
-to connect a Dask distributed client directly.
+If you have a Python session running within the Kubernetes cluster (like the [example one on the Kubernetes
+page](/platforms/kubernetes)) you should be able to connect a Dask distributed client directly.
 
 ```python
 from dask.distributed import Client
@@ -292,7 +303,10 @@ from dask.distributed import Client
 client = Client("rapids-dask-cluster-scheduler:8786")
 ```
 
-Alternatively if you are outside of the Kubernetes cluster you can change the `Service` to use [`LoadBalancer`](https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer) or [`NodePort`](https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport) or use `kubectl` to port forward the connection locally.
+Alternatively if you are outside of the Kubernetes cluster you can change the `Service` to use
+[`LoadBalancer`](https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer) or
+[`NodePort`](https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport) or use `kubectl` to port
+forward the connection locally.
 
 ```console
 $ kubectl port-forward svc/rapids-dask-cluster-service 8786:8786
@@ -307,7 +321,9 @@ client = Client("localhost:8786")
 
 ## Example using `KubeCluster`
 
-In addition to creating clusters via `kubectl` you can also do so from Python with {class}`dask_kubernetes.operator.KubeCluster`. This class implements the Dask Cluster Manager interface and under the hood creates and manages the `DaskCluster` resource for you.
+In addition to creating clusters via `kubectl` you can also do so from Python with
+{class}`dask_kubernetes.operator.KubeCluster`. This class implements the Dask Cluster Manager interface and under the
+hood creates and manages the `DaskCluster` resource for you.
 
 ```python
 from dask_kubernetes.operator import KubeCluster
@@ -321,7 +337,8 @@ cluster = KubeCluster(
 )
 ```
 
-If we check with `kubectl` we can see the above Python generated the same `DaskCluster` resource as the `kubectl` example above.
+If we check with `kubectl` we can see the above Python generated the same `DaskCluster` resource as the `kubectl`
+example above.
 
 ```console
 $ kubectl get daskclusters
@@ -339,7 +356,9 @@ NAME                                  TYPE        CLUSTER-IP      EXTERNAL-IP   
 service/rapids-dask-cluster-service   ClusterIP   10.96.200.202   <none>        8786/TCP,8787/TCP   3m30s
 ```
 
-With this cluster object in Python we can also connect a client to it directly without needing to know the address as Dask will discover that for us. It also automatically sets up port forwarding if you are outside of the Kubernetes cluster.
+With this cluster object in Python we can also connect a client to it directly without needing to know the address as
+Dask will discover that for us. It also automatically sets up port forwarding if you are outside of the Kubernetes
+cluster.
 
 ```python
 from dask.distributed import Client
@@ -360,11 +379,15 @@ cluster.close()
 ```
 
 ```{note}
-By default the `KubeCluster` command registers an exit hook so when the Python process exits the cluster is deleted automatically. You can disable this by setting `KubeCluster(..., shutdown_on_close=False)` when launching the cluster.
+By default the `KubeCluster` command registers an exit hook so when the Python process exits the cluster is deleted
+automatically. You can disable this by setting `KubeCluster(..., shutdown_on_close=False)` when launching the cluster.
 
-This is useful if you have a multi-stage pipeline made up of multiple Python processes and you want your Dask cluster to persist between them.
+This is useful if you have a multi-stage pipeline made up of multiple Python processes and you want your Dask cluster to
+persist between them.
 
-You can also connect a `KubeCluster` object to your existing cluster with `cluster = KubeCluster.from_name(name="rapids-dask")` if you wish to use the cluster or manually call `cluster.close()` in the future.
+You can also connect a `KubeCluster` object to your existing cluster with
+`cluster = KubeCluster.from_name(name="rapids-dask")` if you wish to use the cluster or manually call `cluster.close()`
+in the future.
 ```
 
 ```{relatedexamples}

--- a/source/tools/rapids-docker.md
+++ b/source/tools/rapids-docker.md
@@ -1,6 +1,7 @@
 # Container Images
 
-Installation instructions for Docker are hosted at the [RAPIDS Container Installation Docs Page](https://docs.rapids.ai/install#docker).
+Installation instructions for Docker are hosted at the [RAPIDS Container Installation Docs
+Page](https://docs.rapids.ai/install#docker).
 
 ```{relatedexamples}
 


### PR DESCRIPTION
- Closes #566

Notes:
- Chose 120 charcters becasue for md 80 seemed too short. 
- args: ["--fix"] not always work, as there are some limitations for long paragraphs, but the precommit tells you which line is that you need to shorten. 
- We are ignoring tables
- For some reason some console/bash blocks where been triggered by the linter (only 3 or 4 cases), I was able to ignore them by wrapping them 
```
<!-- markdownlint-disable -->
console block here
<!-- markdownlint-enable -->
``` 
- I applied the linting to each doc that needed it separately, just in case we need to revert something. When squashing delete the message. 