### PR TITLE
Bump nightly tags to CUDA 12.9

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -41,10 +41,10 @@ versions = {
     "nightly": {
         "rapids_version": f"{nightly_version}",
         "rapids_api_docs_version": "nightly",
-        "rapids_container": f"rapidsai/base:{nightly_version + 'a'}-cuda12.8-py3.12",
-        "rapids_notebooks_container": f"rapidsai/notebooks:{nightly_version + 'a'}-cuda12.8-py3.12",
+        "rapids_container": f"rapidsai/base:{nightly_version + 'a'}-cuda12.9-py3.12",
+        "rapids_notebooks_container": f"rapidsai/notebooks:{nightly_version + 'a'}-cuda12.9-py3.12",
         "rapids_conda_channels": "-c rapidsai-nightly -c conda-forge -c nvidia",
-        "rapids_conda_packages": f"rapids={nightly_version} python=3.12 cuda-version=12.8",
+        "rapids_conda_packages": f"rapids={nightly_version} python=3.12 cuda-version=12.9",
         "rapids_pip_index": "https://pypi.anaconda.org/rapidsai-wheels-nightly/simple",
         "rapids_pip_version": f"{nightly_version}.*,>=0.0.0a0",
         # SageMaker Notebook Instance examples need to stay pinned to an older RAPIDS until this is resolved:


### PR DESCRIPTION
Towards #584 (we will need to bump stable as part of the release cc @AyodeAwe)