### PR TITLE
Improve unused image check performance on Mac

### DIFF
--- a/scripts/unused_images.sh
+++ b/scripts/unused_images.sh
@@ -7,7 +7,7 @@ counter=0
 
 for imagepath in $imagepaths; do
     filename=$(basename -- "$imagepath")
-    if ! grep -q -r "$filename" source README.md; then
+    if ! grep -q -r "$filename" --include '*.md' --include '*.ipynb' --include '*.py' source README.md; then
         echo "Found unused image $imagepath"
         counter=$((counter+1))
     fi


### PR DESCRIPTION
The unused images pre-commit check runs slow on Mac, but not on linux.

I usually run things on my workstation which has `grep` 3