### PR TITLE
remove redundant Docker images page

### DIFF
--- a/source/guides/colocate-workers.md
+++ b/source/guides/colocate-workers.md
@@ -71,7 +71,7 @@ Operator has been installed successfully.
 
 To configure the `DaskCluster` resource to run RAPIDS you need to set a few things:
 
-- The container image must contain RAPIDS, the [official RAPIDS container images](/tools/rapids-docker) are a good choice for this.
+- The container image must contain RAPIDS, the [official RAPIDS container images](https://docs.rapids.ai/install/#docker) are a good choice for this.
 - The Dask workers must be configured with one or more NVIDIA GPU resources.
 - The worker command must be set to `dask-cuda-worker`.
 

--- a/source/guides/scheduler-gpu-optimization.md
+++ b/source/guides/scheduler-gpu-optimization.md
@@ -113,7 +113,7 @@ dask-operator   dask-kubernetes-operator-775b8bbbd5-zdrf7   1/1     Running   0 
 
 To configure the `DaskCluster` resource to run RAPIDS you need to set a few things:
 
-- The container image must contain RAPIDS, the [official RAPIDS container images](/tools/rapids-docker) are a good choice for this.
+- The container image must contain RAPIDS, the [official RAPIDS container images](https://docs.rapids.ai/install/#docker) are a good choice for this.
 - The Dask workers must be configured with one or more NVIDIA GPU resources.
 - The worker command must be set to `dask-cuda-worker`.
 

--- a/source/platforms/kubeflow.md
+++ b/source/platforms/kubeflow.md
@@ -8,7 +8,7 @@ These instructions were tested against [Kubeflow v1.5.1](https://github.com/kube
 
 ## Kubeflow Notebooks
 
-The [RAPIDS docker images](/tools/rapids-docker) can be used directly in Kubeflow Notebooks with no additional configuration. To find the latest image head to [the RAPIDS install page](https://docs.rapids.ai/install), as shown in below, and choose a version of RAPIDS to use. Typically we want to choose the container image for the latest release. Verify the Docker image is selected when installing the latest RAPIDS release.
+The [RAPIDS docker images](https://docs.rapids.ai/install/#docker) can be used directly in Kubeflow Notebooks with no additional configuration. To find the latest image head to [the RAPIDS install page](https://docs.rapids.ai/install), as shown in below, and choose a version of RAPIDS to use. Typically we want to choose the container image for the latest release. Verify the Docker image is selected when installing the latest RAPIDS release.
 
 Be sure to match the CUDA version in the container image with that installed on your Kubernetes nodes. The default CUDA version installed on GKE Stable is 11.4 for example, so we would want to choose that. From 11.5 onwards it doesn’t matter as they will be backward compatible. Copy the container image name from the install command (i.e. `{{ rapids_container }}`).
 

--- a/source/platforms/kubernetes.md
+++ b/source/platforms/kubernetes.md
@@ -6,7 +6,7 @@ RAPIDS integrates with Kubernetes in many ways depending on your use case.
 
 ## Interactive Notebook
 
-For single-user interactive sessions you can run the [RAPIDS docker image](/tools/rapids-docker) which contains a conda environment with the RAPIDS libraries and Jupyter for interactive use.
+For single-user interactive sessions you can run the [RAPIDS docker image](https://docs.rapids.ai/install/#docker) which contains a conda environment with the RAPIDS libraries and Jupyter for interactive use.
 
 You can run this directly on Kubernetes as a `Pod` and expose Jupyter via a `Service`. For example:
 

--- a/source/tools/index.md
+++ b/source/tools/index.md
@@ -10,14 +10,6 @@ review_priority: "index"
 :gutter: 2 2 2 2
 
 ````{grid-item-card}
-:link: rapids-docker
-:link-type: doc
-Container Images
-^^^
-Container images containing the RAPIDS software environment.
-````
-
-````{grid-item-card}
 :link: dask-cuda
 :link-type: doc
 Dask CUDA

--- a/source/tools/kubernetes/dask-operator.md
+++ b/source/tools/kubernetes/dask-operator.md
@@ -51,7 +51,7 @@ To install the Dask operator follow the [instructions in the Dask documentation]
 
 To configure the `DaskCluster` resource to run RAPIDS you need to set a few things:
 
-- The container image must contain RAPIDS, the [official RAPIDS container images](/tools/rapids-docker) are a good choice for this.
+- The container image must contain RAPIDS, the [official RAPIDS container images](https://docs.rapids.ai/install/#docker) are a good choice for this.
 - The Dask workers must be configured with one or more NVIDIA GPU resources.
 - The worker command must be set to `dask-cuda-worker`.
 

--- a/source/tools/rapids-docker.md
+++ b/source/tools/rapids-docker.md
@@ -1,7 +1,0 @@
-# Container Images
-
-Installation instructions for Docker are hosted at the [RAPIDS Container Installation Docs Page](https://docs.rapids.ai/install#docker).
-
-```{relatedexamples}
-
-```


### PR DESCRIPTION
Towards https://github.com/rapidsai/deployment/issues/582

Now that we have a separate page describing in detail about running RAPIDS in Docker containers, this page with just a redirect can be safely removed. 

Also changed all the references of RAPIDS docker containers to the official [RAPIDS Docker Install page](https://docs.rapids.ai/install/#docker)