### PR TITLE
Enable manual deployment of the nightly docs

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 # Required shell entrypoint to have properly activated conda environments
 defaults:


### PR DESCRIPTION
It looks like when 8e273b7e4239751cb90905c26603a47cc34b9732 was merged to `main` the GitHub Actions didn't run. Possibly due to a GitHub outage. 

This PR updates the deploy CI to allow `workflow_dispatch` so that we work around this if it happens again and can trigger a deploy of the nightly docs by manually running the workflow in the future.

Merging this PR should also trigger the workflow.