### PR TITLE
Update gha to trigger push to aws when manually dispatching workflow

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -35,7 +35,7 @@ jobs:
         run: uv run make dirhtml SPHINXOPTS="-W --keep-going -n"
 
       - uses: aws-actions/configure-aws-credentials@v4
-        if: ${{ github.repository == 'rapidsai/deployment' && github.event_name == 'push' }}
+        if: ${{ github.repository == 'rapidsai/deployment' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}


### PR DESCRIPTION
In https://github.com/rapidsai/deployment/pull/628 we enable triggering the buld and deploy workflow manually in case we need to. However when we do this, it's not a push action so the nightly docs are not being push to S3. 

This PR fixes that. 