### PR TITLE
Update rapids version to v25.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,10 +157,10 @@ The RAPIDS versions for things like container images and install instructions ar
 ```python
 versions = {
     "stable": {
-        "rapids_container": "nvcr.io/nvidia/rapidsai/base:25.10-cuda12-py3.13",
+        "rapids_container": "nvcr.io/nvidia/rapidsai/base:25.12-cuda12-py3.13",
     },
     "nightly": {
-        "rapids_container": "rapidsai/base:25.12a-cuda12-py3.13",
+        "rapids_container": "rapidsai/base:26.02a-cuda12-py3.13",
     },
 }
 ```

--- a/source/conf.py
+++ b/source/conf.py
@@ -21,8 +21,8 @@ copyright = f"{datetime.date.today().year}, NVIDIA"
 author = "NVIDIA"
 
 # Single modifiable version for all of the docs - easier for future updates
-stable_version = "25.10"
-nightly_version = "25.12"
+stable_version = "25.12"
+nightly_version = "26.02"
 
 versions = {
     "stable": {


### PR DESCRIPTION
Updates documentation for 25.12 release:
- `stable_version`: 25.10 → 25.12
- `nightly_version`: 25.12 → 26.02
- Updated container image references accordingly