### PR TITLE
Update HTML title and redundant section navigation

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -17,6 +17,7 @@ import sys
 # -- Project information -----------------------------------------------------
 
 project = "RAPIDS Deployment Documentation"
+html_title = "RAPIDS Deployment Documentation"
 copyright = f"{datetime.date.today().year}, NVIDIA"
 author = "NVIDIA"
 

--- a/source/local.md
+++ b/source/local.md
@@ -13,7 +13,7 @@ Choose your preferred installation method for running RAPIDS
 ````{grid-item-card}
 :link: https://docs.rapids.ai/install#conda
 :link-type: url
-{fas}`box;sd-text-primary` Conda
+{fas}`box;sd-text-primary` conda
 ^^^
 Install RAPIDS using conda
 ````
@@ -43,10 +43,3 @@ Install RAPIDS on Windows using Windows Subsystem for Linux version 2 (WSL2)
 ````
 
 `````
-
-:::{toctree}
-:hidden:
-:maxdepth: 1
-
-custom-docker.md
-:::


### PR DESCRIPTION
<img width="1166" height="308" alt="image" src="https://github.com/user-attachments/assets/06e48120-555b-497b-a05c-43b22e4e4171" />
Fixes the redundant `documentation` word added by Sphinx in the HTML title

<img width="1461" height="547" alt="image" src="https://github.com/user-attachments/assets/774a3459-efd1-478c-9d9a-ce492817e9c4" />
Also removes redundant link in section navigation