### PR TITLE
Update RAPIDS Custom Docker Documentation from CUDA 12.9.1 to CUDA 13.1.1

### DIFF
--- a/source/custom-docker.md
+++ b/source/custom-docker.md
@@ -45,7 +45,7 @@ The choice of base image depends on how your package manager handles CuPy (a dep
 ### Conda → Uses `cuda-base`
 
 ```dockerfile
-FROM nvidia/cuda:12.9.1-base-ubuntu24.04
+FROM nvidia/cuda:13.1.1-base-ubuntu24.04
 ```
 
 This approach works because conda can install both Python and non-Python dependencies, including system-level CUDA libraries like `libcudart` and `libnvrtc`. When installing RAPIDS libraries via conda, the package manager automatically pulls the required CUDA runtime libraries alongside CuPy and other dependencies, providing complete dependency management in a single installation step.
@@ -53,7 +53,7 @@ This approach works because conda can install both Python and non-Python depende
 ### Pip → Uses `cuda-runtime`
 
 ```dockerfile
-FROM nvidia/cuda:12.9.1-runtime-ubuntu24.04
+FROM nvidia/cuda:13.1.1-runtime-ubuntu24.04
 ```
 
 This approach is necessary because CuPy wheels distributed via PyPI do not currently bundle CUDA runtime libraries (`libcudart`, `libnvrtc`) within the wheel packages themselves. Since pip cannot install system-level CUDA libraries, CuPy expects these libraries to already be present in the system environment. The `cuda-runtime` image provides the necessary CUDA runtime libraries that CuPy requires, eliminating the need for manual library installation.
@@ -133,7 +133,7 @@ docker run --gpus all -it rapids-pip-base
 ```
 
 :::{important}
-When using `pip`, you must specify the CUDA version in the package name (e.g., `cudf-cu12`, `cuml-cu12`). This ensures you install the version of the library that is compatible with the CUDA toolkit.
+When using `pip`, you must specify the CUDA version in the package name (e.g., `cudf-cu13`, `cuml-cu13`). This ensures you install the version of the library that is compatible with the CUDA toolkit.
 :::
 
 ```{note}
@@ -181,7 +181,7 @@ To add packages to the Pip environment, add them to your `requirements.txt` file
 **Example: Adding `scikit-learn` and `lightgbm` to a pip image containing `cudf`**
 
 ```text
-cudf-cu12=={{rapids_pip_version}}
+cudf-cu13=={{rapids_pip_version}}
 scikit-learn
 lightgbm
 ```
@@ -198,7 +198,7 @@ The following variables can be modified at the top of each Dockerfile to customi
 
 | Variable                | Default Value | Description                                            | Example Values       |
 | ----------------------- | ------------- | ------------------------------------------------------ | -------------------- |
-| `CUDA_VER`              | `12.9.1`      | Sets the CUDA version for the base image and packages. | `12.0`               |
+| `CUDA_VER`              | `13.1.1`      | Sets the CUDA version for the base image and packages. | `12.9.1`, `13.0.0`   |
 | `PYTHON_VER` (pip only) | `3.12`        | Defines the Python version to install and use.         | `3.11`, `3.10`       |
 | `LINUX_DISTRO`          | `ubuntu`      | The Linux distribution being used                      | `rockylinux9`, `cm2` |
 | `LINUX_DISTRO_VER`      | `24.04`       | The version of the Linux distribution.                 | `20.04`              |

--- a/source/examples/rapids-custom-docker/rapids-conda.Dockerfile
+++ b/source/examples/rapids-custom-docker/rapids-conda.Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 # Copyright (c) 2024-2025, NVIDIA CORPORATION.
 
-ARG CUDA_VER=12.9.1
+ARG CUDA_VER=13.1.1
 ARG LINUX_DISTRO=ubuntu
 ARG LINUX_DISTRO_VER=24.04
 

--- a/source/examples/rapids-custom-docker/rapids-pip.Dockerfile
+++ b/source/examples/rapids-custom-docker/rapids-pip.Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 # Copyright (c) 2024-2025, NVIDIA CORPORATION.
 
-ARG CUDA_VER=12.9.1
+ARG CUDA_VER=13.1.1
 ARG PYTHON_VER=3.12
 ARG LINUX_DISTRO=ubuntu
 ARG LINUX_DISTRO_VER=24.04
@@ -49,5 +49,7 @@ COPY --chmod=644 requirements.txt /home/rapids/requirements.txt
 
 # Install all packages
 RUN pip install --no-cache-dir -r requirements.txt
+
+ENTRYPOINT []
 
 CMD ["bash"]

--- a/source/examples/rapids-custom-docker/requirements.txt
+++ b/source/examples/rapids-custom-docker/requirements.txt
@@ -1,2 +1,2 @@
 # RAPIDS libraries (pip versions)
-cudf-cu12=={{rapids_pip_version}}
+cudf-cu13=={{rapids_pip_version}}

--- a/source/guides/rapids-docker-with-cuda.md
+++ b/source/guides/rapids-docker-with-cuda.md
@@ -109,7 +109,7 @@ These environment variables are **required** when building CUDA containers, as t
 
 ## Complete Integration Examples
 
-Here are complete examples showing how to build a RAPIDS container with CUDA 12.9.1 components on an Ubuntu 24.04 base image:
+Here are complete examples showing how to build a RAPIDS container with CUDA 13.1.1 components on an Ubuntu 24.04 base image:
 
 ```{tip}
 These examples must be built with Docker v28+.
@@ -144,29 +144,30 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-get purge --autoremove -y curl && \
     rm -rf /var/lib/apt/lists/*
 
-# CUDA Base Package Versions (from CUDA 12.9.1 base image)
-ENV NV_CUDA_CUDART_VERSION=12.9.79-1
-ENV CUDA_VERSION=12.9.1
+# CUDA Base Package Versions (from CUDA 13.1.1 base image)
+ENV NV_CUDA_CUDART_VERSION=13.1.80-1
+ENV CUDA_VERSION=13.1.1
 
 # NVIDIA driver constraints
-ENV NVIDIA_REQUIRE_CUDA="cuda>=12.9 brand=unknown,driver>=535,driver<536 brand=grid,driver>=535,driver<536 brand=tesla,driver>=535,driver<536 brand=nvidia,driver>=535,driver<536 brand=quadro,driver>=535,driver<536 brand=quadrortx,driver>=535,driver<536 brand=nvidiartx,driver>=535,driver<536 brand=vapps,driver>=535,driver<536 brand=vpc,driver>=535,driver<536 brand=vcs,driver>=535,driver<536 brand=vws,driver>=535,driver<536 brand=cloudgaming,driver>=535,driver<536 brand=unknown,driver>=550,driver<551 brand=grid,driver>=550,driver<551 brand=tesla,driver>=550,driver<551 brand=nvidia,driver>=550,driver<551 brand=quadro,driver>=550,driver<551 brand=quadrortx,driver>=550,driver<551 brand=nvidiartx,driver>=550,driver<551 brand=vapps,driver>=550,driver<551 brand=vpc,driver>=550,driver<551 brand=vcs,driver>=550,driver<551 brand=vws,driver>=550,driver<551 brand=cloudgaming,driver>=550,driver<551 brand=unknown,driver>=560,driver<561 brand=grid,driver>=560,driver<561 brand=tesla,driver>=560,driver<561 brand=nvidia,driver>=560,driver<561 brand=quadro,driver>=560,driver<561 brand=quadrortx,driver>=560,driver<561 brand=nvidiartx,driver>=560,driver<561 brand=vapps,driver>=560,driver<561 brand=vpc,driver>=560,driver<561 brand=vcs,driver>=560,driver<561 brand=vws,driver>=560,driver<561 brand=cloudgaming,driver>=560,driver<561 brand=unknown,driver>=565,driver<566 brand=grid,driver>=565,driver<566 brand=tesla,driver>=565,driver<566 brand=nvidia,driver>=565,driver<566 brand=quadro,driver>=565,driver<566 brand=quadrortx,driver>=565,driver<566 brand=nvidiartx,driver>=565,driver<566 brand=vapps,driver>=565,driver<566 brand=vpc,driver>=565,driver<566 brand=vcs,driver>=565,driver<566 brand=vws,driver>=565,driver<566 brand=cloudgaming,driver>=565,driver<566 brand=unknown,driver>=570,driver<571 brand=grid,driver>=570,driver<571 brand=tesla,driver>=570,driver<571 brand=nvidia,driver>=570,driver<571 brand=quadro,driver>=570,driver<571 brand=quadrortx,driver>=570,driver<571 brand=nvidiartx,driver>=570,driver<571 brand=vapps,driver>=570,driver<571 brand=vpc,driver>=570,driver<571 brand=vcs,driver>=570,driver<571 brand=vws,driver>=570,driver<571 brand=cloudgaming,driver>=570,driver<571"
+ENV NVIDIA_REQUIRE_CUDA="cuda>=13.1 brand=unknown,driver>=535,driver<536 brand=grid,driver>=535,driver<536 brand=tesla,driver>=535,driver<536 brand=nvidia,driver>=535,driver<536 brand=quadro,driver>=535,driver<536 brand=quadrortx,driver>=535,driver<536 brand=nvidiartx,driver>=535,driver<536 brand=vapps,driver>=535,driver<536 brand=vpc,driver>=535,driver<536 brand=vcs,driver>=535,driver<536 brand=vws,driver>=535,driver<536 brand=cloudgaming,driver>=535,driver<536 brand=unknown,driver>=550,driver<551 brand=grid,driver>=550,driver<551 brand=tesla,driver>=550,driver<551 brand=nvidia,driver>=550,driver<551 brand=quadro,driver>=550,driver<551 brand=quadrortx,driver>=550,driver<551 brand=nvidiartx,driver>=550,driver<551 brand=vapps,driver>=550,driver<551 brand=vpc,driver>=550,driver<551 brand=vcs,driver>=550,driver<551 brand=vws,driver>=550,driver<551 brand=cloudgaming,driver>=550,driver<551 brand=unknown,driver>=570,driver<571 brand=grid,driver>=570,driver<571 brand=tesla,driver>=570,driver<571 brand=nvidia,driver>=570,driver<571 brand=quadro,driver>=570,driver<571 brand=quadrortx,driver>=570,driver<571 brand=nvidiartx,driver>=570,driver<571 brand=vapps,driver>=570,driver<571 brand=vpc,driver>=570,driver<571 brand=vcs,driver>=570,driver<571 brand=vws,driver>=570,driver<571 brand=cloudgaming,driver>=570,driver<571 brand=unknown,driver>=575,driver<576 brand=grid,driver>=575,driver<576 brand=tesla,driver>=575,driver<576 brand=nvidia,driver>=575,driver<576 brand=quadro,driver>=575,driver<576 brand=quadrortx,driver>=575,driver<576 brand=nvidiartx,driver>=575,driver<576 brand=vapps,driver>=575,driver<576 brand=vpc,driver>=575,driver<576 brand=vcs,driver>=575,driver<576 brand=vws,driver>=575,driver<576 brand=cloudgaming,driver>=575,driver<576 brand=unknown,driver>=580,driver<581 brand=grid,driver>=580,driver<581 brand=tesla,driver>=580,driver<581 brand=nvidia,driver>=580,driver<581 brand=quadro,driver>=580,driver<581 brand=quadrortx,driver>=580,driver<581 brand=nvidiartx,driver>=580,driver<581 brand=vapps,driver>=580,driver<581 brand=vpc,driver>=580,driver<581 brand=vcs,driver>=580,driver<581 brand=vws,driver>=580,driver<581 brand=cloudgaming,driver>=580,driver<581"
 
 # Install Base CUDA Components (from base image)
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    cuda-cudart-12-9=${NV_CUDA_CUDART_VERSION} \
-    cuda-compat-12-9 && \
+    cuda-cudart-13-1=${NV_CUDA_CUDART_VERSION} \
+    cuda-compat-13-1 && \
     rm -rf /var/lib/apt/lists/*
 
 # CUDA Environment Configuration
-ENV PATH=/usr/local/cuda/bin:${PATH}
-ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64
+ENV PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
+ENV LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/usr/local/cuda/lib64
 
 # NVIDIA Container Runtime Configuration
 ENV NVIDIA_VISIBLE_DEVICES=all
 ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility
 
 # Required for nvidia-docker v1
-RUN echo "/usr/local/cuda/lib64" >> /etc/ld.so.conf.d/nvidia.conf
+RUN echo "/usr/local/nvidia/lib64" >> /etc/ld.so.conf.d/nvidia.conf && \
+    echo "/usr/local/cuda/lib64" >> /etc/ld.so.conf.d/nvidia.conf
 
 # Install system dependencies
 RUN apt-get update && \
@@ -238,54 +239,50 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-get purge --autoremove -y curl && \
     rm -rf /var/lib/apt/lists/*
 
-# CUDA Package Versions (from CUDA 12.9.1 base and runtime images)
-ENV NV_CUDA_CUDART_VERSION=12.9.79-1
-ENV NV_CUDA_LIB_VERSION=12.9.1-1
-ENV NV_NVTX_VERSION=12.9.79-1
-ENV NV_LIBNPP_VERSION=12.4.1.87-1
-ENV NV_LIBNPP_PACKAGE=libnpp-12-9=${NV_LIBNPP_VERSION}
-ENV NV_LIBCUSPARSE_VERSION=12.5.10.65-1
-ENV NV_LIBCUBLAS_PACKAGE_NAME=libcublas-12-9
-ENV NV_LIBCUBLAS_VERSION=12.9.1.4-1
+# CUDA Package Versions (from CUDA 13.1.1 base and runtime images)
+ENV NV_CUDA_CUDART_VERSION=13.1.80-1
+ENV CUDA_VERSION=13.1.1
+ENV NV_CUDA_LIB_VERSION=13.1.1-1
+ENV NV_NVTX_VERSION=13.1.115-1
+ENV NV_LIBNPP_VERSION=13.0.3.3-1
+ENV NV_LIBNPP_PACKAGE=libnpp-13-1=${NV_LIBNPP_VERSION}
+ENV NV_LIBCUSPARSE_VERSION=12.7.3.1-1
+ENV NV_LIBCUBLAS_PACKAGE_NAME=libcublas-13-1
+ENV NV_LIBCUBLAS_VERSION=13.2.1.1-1
 ENV NV_LIBCUBLAS_PACKAGE=${NV_LIBCUBLAS_PACKAGE_NAME}=${NV_LIBCUBLAS_VERSION}
-ENV NV_LIBNCCL_PACKAGE_NAME=libnccl2
-ENV NV_LIBNCCL_PACKAGE_VERSION=2.27.3-1
-ENV NCCL_VERSION=2.27.3-1
-ENV NV_LIBNCCL_PACKAGE=${NV_LIBNCCL_PACKAGE_NAME}=${NV_LIBNCCL_PACKAGE_VERSION}+cuda12.9
-ENV CUDA_VERSION=12.9.1
 
 # NVIDIA driver constraints
-ENV NVIDIA_REQUIRE_CUDA="cuda>=12.9 brand=unknown,driver>=535,driver<536 brand=grid,driver>=535,driver<536 brand=tesla,driver>=535,driver<536 brand=nvidia,driver>=535,driver<536 brand=quadro,driver>=535,driver<536 brand=quadrortx,driver>=535,driver<536 brand=nvidiartx,driver>=535,driver<536 brand=vapps,driver>=535,driver<536 brand=vpc,driver>=535,driver<536 brand=vcs,driver>=535,driver<536 brand=vws,driver>=535,driver<536 brand=cloudgaming,driver>=535,driver<536 brand=unknown,driver>=550,driver<551 brand=grid,driver>=550,driver<551 brand=tesla,driver>=550,driver<551 brand=nvidia,driver>=550,driver<551 brand=quadro,driver>=550,driver<551 brand=quadrortx,driver>=550,driver<551 brand=nvidiartx,driver>=550,driver<551 brand=vapps,driver>=550,driver<551 brand=vpc,driver>=550,driver<551 brand=vcs,driver>=550,driver<551 brand=vws,driver>=550,driver<551 brand=cloudgaming,driver>=550,driver<551 brand=unknown,driver>=560,driver<561 brand=grid,driver>=560,driver<561 brand=tesla,driver>=560,driver<561 brand=nvidia,driver>=560,driver<561 brand=quadro,driver>=560,driver<561 brand=quadrortx,driver>=560,driver<561 brand=nvidiartx,driver>=560,driver<561 brand=vapps,driver>=560,driver<561 brand=vpc,driver>=560,driver<561 brand=vcs,driver>=560,driver<561 brand=vws,driver>=560,driver<561 brand=cloudgaming,driver>=560,driver<561 brand=unknown,driver>=565,driver<566 brand=grid,driver>=565,driver<566 brand=tesla,driver>=565,driver<566 brand=nvidia,driver>=565,driver<566 brand=quadro,driver>=565,driver<566 brand=quadrortx,driver>=565,driver<566 brand=nvidiartx,driver>=565,driver<566 brand=vapps,driver>=565,driver<566 brand=vpc,driver>=565,driver<566 brand=vcs,driver>=565,driver<566 brand=vws,driver>=565,driver<566 brand=cloudgaming,driver>=565,driver<566 brand=unknown,driver>=570,driver<571 brand=grid,driver>=570,driver<571 brand=tesla,driver>=570,driver<571 brand=nvidia,driver>=570,driver<571 brand=quadro,driver>=570,driver<571 brand=quadrortx,driver>=570,driver<571 brand=nvidiartx,driver>=570,driver<571 brand=vapps,driver>=570,driver<571 brand=vpc,driver>=570,driver<571 brand=vcs,driver>=570,driver<571 brand=vws,driver>=570,driver<571 brand=cloudgaming,driver>=570,driver<571"
+ENV NVIDIA_REQUIRE_CUDA="cuda>=13.1 brand=unknown,driver>=535,driver<536 brand=grid,driver>=535,driver<536 brand=tesla,driver>=535,driver<536 brand=nvidia,driver>=535,driver<536 brand=quadro,driver>=535,driver<536 brand=quadrortx,driver>=535,driver<536 brand=nvidiartx,driver>=535,driver<536 brand=vapps,driver>=535,driver<536 brand=vpc,driver>=535,driver<536 brand=vcs,driver>=535,driver<536 brand=vws,driver>=535,driver<536 brand=cloudgaming,driver>=535,driver<536 brand=unknown,driver>=550,driver<551 brand=grid,driver>=550,driver<551 brand=tesla,driver>=550,driver<551 brand=nvidia,driver>=550,driver<551 brand=quadro,driver>=550,driver<551 brand=quadrortx,driver>=550,driver<551 brand=nvidiartx,driver>=550,driver<551 brand=vapps,driver>=550,driver<551 brand=vpc,driver>=550,driver<551 brand=vcs,driver>=550,driver<551 brand=vws,driver>=550,driver<551 brand=cloudgaming,driver>=550,driver<551 brand=unknown,driver>=570,driver<571 brand=grid,driver>=570,driver<571 brand=tesla,driver>=570,driver<571 brand=nvidia,driver>=570,driver<571 brand=quadro,driver>=570,driver<571 brand=quadrortx,driver>=570,driver<571 brand=nvidiartx,driver>=570,driver<571 brand=vapps,driver>=570,driver<571 brand=vpc,driver>=570,driver<571 brand=vcs,driver>=570,driver<571 brand=vws,driver>=570,driver<571 brand=cloudgaming,driver>=570,driver<571 brand=unknown,driver>=575,driver<576 brand=grid,driver>=575,driver<576 brand=tesla,driver>=575,driver<576 brand=nvidia,driver>=575,driver<576 brand=quadro,driver>=575,driver<576 brand=quadrortx,driver>=575,driver<576 brand=nvidiartx,driver>=575,driver<576 brand=vapps,driver>=575,driver<576 brand=vpc,driver>=575,driver<576 brand=vcs,driver>=575,driver<576 brand=vws,driver>=575,driver<576 brand=cloudgaming,driver>=575,driver<576 brand=unknown,driver>=580,driver<581 brand=grid,driver>=580,driver<581 brand=tesla,driver>=580,driver<581 brand=nvidia,driver>=580,driver<581 brand=quadro,driver>=580,driver<581 brand=quadrortx,driver>=580,driver<581 brand=nvidiartx,driver>=580,driver<581 brand=vapps,driver>=580,driver<581 brand=vpc,driver>=580,driver<581 brand=vcs,driver>=580,driver<581 brand=vws,driver>=580,driver<581 brand=cloudgaming,driver>=580,driver<581"
 
 # Install Base CUDA Components
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    cuda-cudart-12-9=${NV_CUDA_CUDART_VERSION} \
-    cuda-compat-12-9 && \
+    cuda-cudart-13-1=${NV_CUDA_CUDART_VERSION} \
+    cuda-compat-13-1 && \
     rm -rf /var/lib/apt/lists/*
 
 # Install Runtime CUDA Components
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    cuda-libraries-12-9=${NV_CUDA_LIB_VERSION} \
+    cuda-libraries-13-1=${NV_CUDA_LIB_VERSION} \
     ${NV_LIBNPP_PACKAGE} \
-    cuda-nvtx-12-9=${NV_NVTX_VERSION} \
-    libcusparse-12-9=${NV_LIBCUSPARSE_VERSION} \
+    cuda-nvtx-13-1=${NV_NVTX_VERSION} \
+    libcusparse-13-1=${NV_LIBCUSPARSE_VERSION} \
     ${NV_LIBCUBLAS_PACKAGE} \
-    ${NV_LIBNCCL_PACKAGE} && \
-    rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/*
 
 # Keep apt from auto upgrading the cublas and nccl packages
-RUN apt-mark hold ${NV_LIBCUBLAS_PACKAGE_NAME} ${NV_LIBNCCL_PACKAGE_NAME}
+RUN apt-mark hold ${NV_LIBCUBLAS_PACKAGE_NAME}
 
 # CUDA Environment Configuration
-ENV PATH=/usr/local/cuda/bin:${PATH}
-ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64
+ENV PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
+ENV LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/usr/local/cuda/lib64
 
 # NVIDIA Container Runtime Configuration
 ENV NVIDIA_VISIBLE_DEVICES=all
 ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility
 
 # Required for nvidia-docker v1
-RUN echo "/usr/local/cuda/lib64" >> /etc/ld.so.conf.d/nvidia.conf
+RUN echo "/usr/local/nvidia/lib64" >> /etc/ld.so.conf.d/nvidia.conf && \
+    echo "/usr/local/cuda/lib64" >> /etc/ld.so.conf.d/nvidia.conf
 
 # Install system dependencies
 RUN apt-get update && \
@@ -323,6 +320,8 @@ COPY --chmod=644 requirements.txt /home/rapids/requirements.txt
 
 # Install all packages
 RUN pip install --no-cache-dir -r requirements.txt
+
+ENTRYPOINT []
 
 CMD ["bash"]
 ```


### PR DESCRIPTION
  Updated all documentation to use CUDA 13.1.1 to align with RAPIDS 25.12's CUDA 13 support.

  - Updated example Dockerfiles to use CUDA 13.1.1 base images
  - Changed pip package suffix from `cudf-cu12` to `cudf-cu13`
  - Updated all CUDA package versions in the custom base image guide to match official NVIDIA CUDA 13.1.1 Dockerfiles
  - Removed NCCL packages from pip section (not in official runtime images)
  - Added `ENTRYPOINT []` to pip Dockerfiles to suppress license message produced by the CUDA Runtime images.

  I also tested GPU visibility, a basic cuDF test and CUDA versions by building these Docker images on the `dlcluster`