### PR TITLE
Security Fix: Don't bind ports on all interfaces in Brev Launchables.

### DIFF
--- a/source/cloud/nvidia/brev.md
+++ b/source/cloud/nvidia/brev.md
@@ -98,7 +98,7 @@ You can read more about Brev Launchables in the [Getting Started Guide](https://
          user: root
          working_dir: /notebooks
          entrypoint: ["/home/rapids/entrypoint.sh"]
-         command: python -m jupyter lab --allow-root --ip=0.0.0.0 --no-browser --NotebookApp.token='' --NotebookApp.password='' --notebook-dir=/notebooks
+         command: python -m jupyter lab --allow-root --ip=127.0.0.1 --no-browser --NotebookApp.token='' --NotebookApp.password='' --notebook-dir=/notebooks
          restart: unless-stopped
       ```
 


### PR DESCRIPTION
Brev Launchable docker composes should only expose services on 127.0.0.1.

These examples/templates don't explicitly list what address to bind to, but in Docker Compose, when you define ports as "8000," I believe it binds to all interfaces by default.