### PR TITLE
Update azure ml docs 

### DIFF
--- a/source/cloud/azure/azureml.md
+++ b/source/cloud/azure/azureml.md
@@ -28,7 +28,7 @@ The compute instance provides an integrated Jupyter notebook service, JupyterLab
 
 Sign in to [Azure Machine Learning Studio](https://ml.azure.com/) and navigate to your workspace on the left-side menu.
 
-Select **New** > **Compute instance** (Create compute instance) > choose an [Azure RAPIDS compatible GPU](https://docs.rapids.ai/deployment/stable/cloud/azure/) VM size (e.g., `Standard_NC12s_v3`)
+Select **New** > **Compute instance** (Create compute instance) > choose an [Azure RAPIDS compatible GPU](https://docs.rapids.ai/deployment/stable/cloud/azure/) VM size (e.g., `Standard_NC6s_v3`)
 
 ![Screenshot of create new notebook with a gpu-instance](../../images/azureml-create-notebook-instance.png)
 

--- a/source/examples/rapids-azureml-hpo/rapids_csp_azure.py
+++ b/source/examples/rapids-azureml-hpo/rapids_csp_azure.py
@@ -29,7 +29,7 @@ import pyarrow.orc as pyarrow_orc
 import sklearn
 import xgboost
 from cuml.dask.common import utils as dask_utils
-from cuml.metrics.accuracy import accuracy_score
+from cuml.metrics import accuracy_score
 from cuml.model_selection import train_test_split as cuml_train_test_split
 from dask.distributed import Client
 from dask_cuda import LocalCUDACluster
@@ -277,8 +277,8 @@ class RapidsCloudML:
             elif "GPU" in self.compute_type:
                 if "single" in self.compute_type:
                     X_train, X_test, y_train, y_test = cuml_train_test_split(
-                        X=dataset,
-                        y=y_label,
+                        dataset,
+                        y_label,
                         train_size=train_size,
                         shuffle=shuffle,
                         random_state=random_state,


### PR DESCRIPTION
- Closes https://github.com/rapidsai/deployment/issues/657
- Tested everything except the praameter sweep since it takes a while. 



<details>
<summary> Confirmation that the fixes work</summary>


```txt
---->>>> cuML version <<<<----
 26.02.00a144

> RapidsCloudML
	Compute, Data, Model, Cloud types ('single-GPU', 'Parquet', 'RandomForest', 'Azure')
single-GPU

> Loading dataset from /mnt/azureml/cr/j/7d759460a43140d2bdd10e51177475e3/cap/data-capability/wd/INPUT_data_dir/airline_20000000.parquet

	GPU read

	Ingestion completed in 1.0664729300000317

	Dataset descriptors: (20000000, 14)
	ArrDelayBinary         int32
Year                 float32
Month                float32
DayofMonth           float32
DayofWeek            float32
CRSDepTime           float32
CRSArrTime           float32
UniqueCarrier        float32
FlightNum            float32
ActualElapsedTime    float32
Origin               float32
Dest                 float32
Distance             float32
Diverted             float32
dtype: object

---->>>> Training using GPUs <<<<----


 CV fold 0 of 5


> Splitting train and test data

	X_train shape and type(16000000, 13) <class 'cudf.core.dataframe.DataFrame'>

	Split completed in 0.9020613200000298

> Training RandomForest estimator w/ hyper-params

	Finished training in 41.5718 s

> Inferencing on test set

	Finished inference in 5.2121 s

	Test-accuracy: 0.8517995

 CV fold 1 of 5


> Splitting train and test data

	X_train shape and type(16000000, 13) <class 'cudf.core.dataframe.DataFrame'>

	Split completed in 1.0703475950000438

> Training RandomForest estimator w/ hyper-params

	Finished training in 41.8571 s

> Inferencing on test set

	Finished inference in 0.0498 s

	Test-accuracy: 0.85192225

 CV fold 2 of 5


> Splitting train and test data

	X_train shape and type(16000000, 13) <class 'cudf.core.dataframe.DataFrame'>

	Split completed in 0.8669627619999574

> Training RandomForest estimator w/ hyper-params

	Finished training in 41.8795 s

> Inferencing on test set

	Finished inference in 0.0505 s

	Test-accuracy: 0.8521945

 CV fold 3 of 5


> Splitting train and test data

	X_train shape and type(16000000, 13) <class 'cudf.core.dataframe.DataFrame'>

	Split completed in 1.0718232459998944

> Training RandomForest estimator w/ hyper-params

	Finished training in 41.2962 s

> Inferencing on test set

	Finished inference in 0.0491 s

	Test-accuracy: 0.85178475

 CV fold 4 of 5


> Splitting train and test data

	X_train shape and type(16000000, 13) <class 'cudf.core.dataframe.DataFrame'>

	Split completed in 0.8877701820000539

> Training RandomForest estimator w/ hyper-params

	Finished training in 41.5171 s

> Inferencing on test set

	Finished inference in 0.0494 s

	Test-accuracy: 0.8517765

 Accuracy             : 0.8521945

 accuracy per fold    : [0.8518, 0.8519, 0.8522, 0.8518, 0.8518]

 train-time per fold  : [41.5718, 41.8571, 41.8795, 41.2962, 41.5171]

 train-time all folds : 208.1217

 infer-time per fold  : [5.2121, 0.0498, 0.0505, 0.0491, 0.0494]

 infer-time all folds : 5.410900000000001
Total runtime: 221.83

 Exiting script
```

</details>