### PR TITLE
Update version for 26.02 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,10 +157,10 @@ The RAPIDS versions for things like container images and install instructions ar
 ```python
 versions = {
     "stable": {
-        "rapids_container": "nvcr.io/nvidia/rapidsai/base:25.12-cuda12-py3.13",
+        "rapids_container": "nvcr.io/nvidia/rapidsai/base:26.02-cuda12-py3.13",
     },
     "nightly": {
-        "rapids_container": "rapidsai/base:26.02a-cuda12-py3.13",
+        "rapids_container": "rapidsai/base:26.04a-cuda12-py3.13",
     },
 }
 ```

--- a/source/conf.py
+++ b/source/conf.py
@@ -22,8 +22,8 @@ copyright = f"{datetime.date.today().year}, NVIDIA"
 author = "NVIDIA"
 
 # Single modifiable version for all of the docs - easier for future updates
-stable_version = "25.12"
-nightly_version = "26.02"
+stable_version = "26.02"
+nightly_version = "26.04"
 
 versions = {
     "stable": {


### PR DESCRIPTION
Update deployment documentation versions for the 26.02 release.

Changes:
- stable_version: 25.12 → 26.02
- nightly_version: 26.02 → 26.04
- Container image refs updated accordingly