### PR TITLE
remove reference to 'nvidia' conda channel

### DIFF
--- a/source/custom-docker.md
+++ b/source/custom-docker.md
@@ -167,7 +167,6 @@ name: base
 channels:
   - {{ rapids_conda_channels_list[0] }}
   - conda-forge
-  - nvidia
 dependencies:
   - cudf={{rapids_version}}
   - scikit-learn

--- a/source/examples/rapids-custom-docker/env.yaml
+++ b/source/examples/rapids-custom-docker/env.yaml
@@ -2,7 +2,6 @@ name: base
 channels:
   - "{{ rapids_conda_channels_list[0] }}"
   - conda-forge
-  - nvidia
 dependencies:
   - python=3.12
   - cudf={{rapids_version}}

--- a/source/platforms/coiled.md
+++ b/source/platforms/coiled.md
@@ -65,7 +65,6 @@ name: rapidsai-notebooks
 channels:
   - { { rapids_conda_channel } }
   - conda-forge
-  - nvidia
 dependencies:
   # RAPIDS packages
   - rapids={{ rapids_version }}


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/254

RAPIDS dropped almost all usage of the `nvidia` conda channel when it dropped CUDA 11 support last year (https://github.com/rapidsai/build-planning/issues/184).

Since at least RAPIDS 25.12 it hasn't needed it at all (https://github.com/rapidsai/build-planning/issues/223#issuecomment-3474642026)

This removes it from conda channel lists in all examples here.