### PR TITLE
Fixes after testing on Databricks

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -59,10 +59,6 @@ versions = {
         "rapids_conda_channels": "-c rapidsai-nightly -c conda-forge",
         "rapids_conda_packages": f"rapids={nightly_version} python={python_version} '{nightly_cuda_range}'",
         "rapids_pip_index": "https://pypi.anaconda.org/rapidsai-wheels-nightly/simple",
-        # Callers pin with '==', so this must stay a bare version. The trailing
-        # '>=0.0.0a0' is an unbounded no-op whose only job is to put a prerelease
-        # marker in the specifier set, which is what makes pip consider nightly
-        # prereleases without needing '--pre'.
         "rapids_pip_version": f"{nightly_version}.*,>=0.0.0a0",
         "rapids_cuda_major": cuda_major,
         "rapids_cuda_version_range": nightly_cuda_range,

--- a/source/conf.py
+++ b/source/conf.py
@@ -59,7 +59,11 @@ versions = {
         "rapids_conda_channels": "-c rapidsai-nightly -c conda-forge",
         "rapids_conda_packages": f"rapids={nightly_version} python={python_version} '{nightly_cuda_range}'",
         "rapids_pip_index": "https://pypi.anaconda.org/rapidsai-wheels-nightly/simple",
-        "rapids_pip_version": f"~={nightly_version}.0a0",
+        # Callers pin with '==', so this must stay a bare version. The trailing
+        # '>=0.0.0a0' is an unbounded no-op whose only job is to put a prerelease
+        # marker in the specifier set, which is what makes pip consider nightly
+        # prereleases without needing '--pre'.
+        "rapids_pip_version": f"{nightly_version}.*,>=0.0.0a0",
         "rapids_cuda_major": cuda_major,
         "rapids_cuda_version_range": nightly_cuda_range,
         # AzureML is pinned to CUDA 12 currently (driver 535.x supports only CUDA 12.x).

--- a/source/platforms/databricks.md
+++ b/source/platforms/databricks.md
@@ -42,8 +42,8 @@ To get started, navigate to the **All Purpose Compute** tab of the **Compute** s
 
 ![Screenshot of the Databricks compute page](../images/databricks-create-compute.png)
 
-In order to launch a GPU node check the **Machine Learning** box and uncheck the **Use Photon Acceleration** box just below it, then select an LTS runtime with GPU support.
-For example you could select the `18 LTS (includes Apache Spark 4.1.0, GPU, Scala 2.13)` runtime version.
+In order to launch a GPU node check the **Machine Learning** box and uncheck the **Use Photon Acceleration** box just below it, then select a runtime in the dropdown.
+For example you could select the `18 LTS (Scala 2.13, Spark 4.1.0)` runtime version.
 
 The "GPU accelerated" nodes should now be available in the **Node type** dropdown.
 

--- a/source/platforms/databricks.md
+++ b/source/platforms/databricks.md
@@ -42,8 +42,8 @@ To get started, navigate to the **All Purpose Compute** tab of the **Compute** s
 
 ![Screenshot of the Databricks compute page](../images/databricks-create-compute.png)
 
-In order to launch a GPU node uncheck **Use Photon Acceleration** and select any `15.x`, `16.x` or `17.x` ML LTS runtime with GPU support.
-For example for long-term support releases you could select the `15.4 LTS ML (includes Apache Spark 3.5.0, GPU, Scala 2.12)` runtime version.
+In order to launch a GPU node uncheck **Use Photon Acceleration** and select an ML LTS runtime with GPU support.
+For example you could select the `18 LTS ML (includes Apache Spark 4.1.0, GPU, Scala 2.13)` runtime version.
 
 The "GPU accelerated" nodes should now be available in the **Node type** dropdown.
 

--- a/source/platforms/databricks.md
+++ b/source/platforms/databricks.md
@@ -26,14 +26,9 @@ Navigate to the top-left **Workspace** tab and click on your **Home** directory 
 #!/bin/bash
 set -e
 
-# The Databricks ML runtime preinstalls cupy-cuda12x. RAPIDS CUDA 13 wheels
-# need the matching cupy-cuda13x build, so replace it before installing.
-pip uninstall -y cupy-cuda12x
-
 # Install RAPIDS libraries
 pip install \
     --extra-index-url={{rapids_pip_index}} \
-    "cupy-cuda{{rapids_cuda_major}}x" \
     "cudf-cu{{rapids_cuda_major}}=={{rapids_pip_version}}" "cuml-cu{{rapids_cuda_major}}=={{rapids_pip_version}}" \
     "dask-cuda=={{rapids_pip_version}}"
 

--- a/source/platforms/databricks.md
+++ b/source/platforms/databricks.md
@@ -42,8 +42,8 @@ To get started, navigate to the **All Purpose Compute** tab of the **Compute** s
 
 ![Screenshot of the Databricks compute page](../images/databricks-create-compute.png)
 
-In order to launch a GPU node uncheck **Use Photon Acceleration** and select an ML LTS runtime with GPU support.
-For example you could select the `18 LTS ML (includes Apache Spark 4.1.0, GPU, Scala 2.13)` runtime version.
+In order to launch a GPU node check the **Machine Learning** box and uncheck the **Use Photon Acceleration** box just below it, then select an LTS runtime with GPU support.
+For example you could select the `18 LTS (includes Apache Spark 4.1.0, GPU, Scala 2.13)` runtime version.
 
 The "GPU accelerated" nodes should now be available in the **Node type** dropdown.
 

--- a/source/platforms/modal.md
+++ b/source/platforms/modal.md
@@ -64,6 +64,7 @@ ctk_image = modal.Image.from_registry(
 
 image = ctk_image.uv_pip_install(
     "cudf-cu{{ rapids_cuda_major }}=={{ rapids_pip_version }}",
+    extra_index_url="{{ rapids_pip_index }}",
 ).env({"CUDF_PANDAS_RMM_MODE": "async"})
 
 

--- a/source/platforms/modal.md
+++ b/source/platforms/modal.md
@@ -63,7 +63,7 @@ ctk_image = modal.Image.from_registry(
 
 
 image = ctk_image.uv_pip_install(
-    "cudf-cu{{ rapids_cuda_major }}=={{ rapids_version }}",
+    "cudf-cu{{ rapids_cuda_major }}=={{ rapids_pip_version }}",
 ).env({"CUDF_PANDAS_RMM_MODE": "async"})
 
 


### PR DESCRIPTION
Merging #719 with additional templating created an issue with nightly version string. This PR fixes that. 

Also tested out all the instructions on Databricks 18 LTS runtime with Machine Learning enabled, and `cupy` is not installed on this environment, which makes the `init-script` shorter. 

Going through instances of nightly pip versioning, I noticed that modal was not using the pip versioning while installing with `uv`, so this PR updates that