### PR TITLE
X-ORG-722: Ensure gha-tools are installed

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -21,6 +21,7 @@ jobs:
   build:
     name: Build (and deploy)
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
@@ -53,6 +54,11 @@ jobs:
           VERSION: ${{ steps.set-version.outputs.VERSION }}
         if: ${{ github.repository == 'rapidsai/deployment' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
         run: aws s3 sync --no-progress --delete build/dirhtml "s3://rapidsai-docs/deployment/html/${VERSION}"
+
+      - name: Download gha-tools with git clone
+        run: |
+          git clone https://github.com/rapidsai/gha-tools.git -b main /tmp/gha-tools
+          echo "/tmp/gha-tools/tools" >> "${GITHUB_PATH}"
 
       - name: Publish to docs.nvidia.com
         if: ${{ github.repository == 'rapidsai/deployment' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}


### PR DESCRIPTION
Contributes to #722 

Noticed a couple problems in the [previous PR](https://github.com/rapidsai/deployment/pull/724)'s build post-merge: https://github.com/rapidsai/deployment/actions/runs/30579742034

- The `publish-docs` action assumes we're inside a CI container because it doesn't use `sudo` for its `apt-get install`. This is now fixed via https://github.com/rapidsai/shared-actions/pull/133
- We also need https://github.com/rapidsai/gha-tools installed.

I tried to run the entire workflow in a CI container, but those have Python 3.14, while this build appears to expect 3.12, and there are some Python package installation problems I don't have bandwidth for at the moment.
