### PR TITLE
Enable public docs feature in CI

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -140,6 +140,7 @@ html_theme_options = {
             "type": "fontawesome",
         },
     ],
+    "public_docs_features": os.environ.get("CI") == "true",
     "external_links": [
         {"name": "Docs Home", "url": "https://docs.rapids.ai/"},
     ],


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/319

Enable the NVIDIA Sphinx theme’s `public_docs_features` option when `CI=true`, while leaving local documentation builds unchanged.

